### PR TITLE
Fix Haiku build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,13 @@ ifneq (,$(findstring unix,$(platform)))
 
     TARGET := $(TARGET_NAME)_libretro.so
     fpic := -fPIC
-    ifneq ($(findstring SunOS,$(shell uname -a)),)
-            SHARED := -shared -lpthread -lm -z defs -z gnu-version-script-compat
-        else
-            SHARED := -lpthread -lm -shared -Wl,--no-undefined -Wl,--version-script=link.T
+    ifneq ($(findstring SunOS,$(shell uname -s)),)
+        SHARED := -shared -lpthread -lm -z defs -z gnu-version-script-compat
+    else
+        SHARED := -lpthread -lm -shared -Wl,--no-undefined -Wl,--version-script=link.T
+        ifeq ($(findstring Haiku,$(shell uname -s)),)
             HAVE_CDROM = 1
+        endif
     endif
 
     THREADED_DSP = 1


### PR DESCRIPTION
This fixes the Haiku build which got broken after changes in cdrom.c in libretro-common
Deactivating CD-ROM in Haiku for now allows the core to build and run again