### PR TITLE
A broader fix to restore build on non-Linux systems like Solaris or BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ifneq (,$(findstring unix,$(platform)))
         SHARED := -shared -lpthread -lm -z defs
     else
         SHARED := -lpthread -lm -shared -Wl,--no-undefined -Wl,--version-script=link.T
-        ifeq ($(findstring Haiku,$(shell uname -s)),)
+        ifneq ($(findstring Linux,$(shell uname -s)),)
             HAVE_CDROM = 1
         endif
     endif


### PR DESCRIPTION
Similar to https://github.com/libretro/beetle-saturn-libretro/pull/168 this will allow building on non-Android Unix systems that are not Linux (like Solaris or derivatives, and BSD)