### PR TITLE
Fix threaded DSP + switch to rthreads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DEBUG = 0
 HAVE_CHD = 1
-THREADED_DSP=0
+THREADED_DSP = 1
 HAVE_CDROM = 0
 
 ifeq ($(platform),)
@@ -63,8 +63,6 @@ ifneq (,$(findstring unix,$(platform)))
         endif
     endif
 
-    THREADED_DSP = 1
-
     # Raspberry Pi
     ifneq (,$(findstring rpi,$(platform)))
         CFLAGS += -fomit-frame-pointer -ffast-math -DARM -marm -mfloat-abi=hard
@@ -124,7 +122,6 @@ else ifeq ($(platform), classic_armv7_a7)
 	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
 	HAVE_NEON = 1
 	ARCH = arm
-	THREADED_DSP = 1
 	ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
 	  CFLAGS += -march=armv7-a
 	else
@@ -307,6 +304,7 @@ else ifeq ($(platform), libnx)
 else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
+   THREADED_DSP = 0
 
 # Windows MSVC 2003 Xbox 1
 else ifeq ($(platform), xbox1_msvc2003)

--- a/Makefile.common
+++ b/Makefile.common
@@ -104,6 +104,10 @@ endif
 
 ifeq ($(THREADED_DSP), 1)
 FLAGS += -DTHREADED_DSP
+    ifneq ($(STATIC_LINKING), 1)
+    SOURCES_C += \
+            $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c
+    endif
 endif
 
 ifeq ($(HAVE_CHD), 1)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,4 +1,5 @@
 HAVE_CHD = 1
+THREADED_DSP = 1
 
 LOCAL_PATH := $(call my-dir)
 

--- a/libretro-common/include/rthreads/rthreads.h
+++ b/libretro-common/include/rthreads/rthreads.h
@@ -1,0 +1,269 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rthreads.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_RTHREADS_H__
+#define __LIBRETRO_SDK_RTHREADS_H__
+
+#include <retro_common_api.h>
+
+#include <boolean.h>
+#include <stdint.h>
+#include <retro_inline.h>
+#include <retro_miscellaneous.h>
+
+RETRO_BEGIN_DECLS
+
+typedef struct sthread sthread_t;
+typedef struct slock slock_t;
+typedef struct scond scond_t;
+
+#ifdef HAVE_THREAD_STORAGE
+typedef unsigned sthread_tls_t;
+#endif
+
+/**
+ * sthread_create:
+ * @start_routine           : thread entry callback function
+ * @userdata                : pointer to userdata that will be made
+ *                            available in thread entry callback function
+ *
+ * Create a new thread.
+ *
+ * Returns: pointer to new thread if successful, otherwise NULL.
+ */
+sthread_t *sthread_create(void (*thread_func)(void*), void *userdata);
+
+/**
+ * sthread_create_with_priority:
+ * @start_routine           : thread entry callback function
+ * @userdata                : pointer to userdata that will be made
+ *                            available in thread entry callback function
+ * @thread_priority         : thread priority hint value from [1-100]
+ *
+ * Create a new thread. It is possible for the caller to give a hint
+ * for the thread's priority from [1-100]. Any passed in @thread_priority
+ * values that are outside of this range will cause sthread_create() to
+ * create a new thread using the operating system's default thread
+ * priority.
+ *
+ * Returns: pointer to new thread if successful, otherwise NULL.
+ */
+sthread_t *sthread_create_with_priority(void (*thread_func)(void*), void *userdata, int thread_priority);
+
+/**
+ * sthread_detach:
+ * @thread                  : pointer to thread object
+ *
+ * Detach a thread. When a detached thread terminates, its
+ * resource sare automatically released back to the system
+ * without the need for another thread to join with the
+ * terminated thread.
+ *
+ * Returns: 0 on success, otherwise it returns a non-zero error number.
+ */
+int sthread_detach(sthread_t *thread);
+
+/**
+ * sthread_join:
+ * @thread                  : pointer to thread object
+ *
+ * Join with a terminated thread. Waits for the thread specified by
+ * @thread to terminate. If that thread has already terminated, then
+ * it will return immediately. The thread specified by @thread must
+ * be joinable.
+ *
+ * Returns: 0 on success, otherwise it returns a non-zero error number.
+ */
+void sthread_join(sthread_t *thread);
+
+/**
+ * sthread_isself:
+ * @thread                  : pointer to thread object
+ *
+ * Returns: true (1) if calling thread is the specified thread
+ */
+bool sthread_isself(sthread_t *thread);
+
+/**
+ * slock_new:
+ *
+ * Create and initialize a new mutex. Must be manually
+ * freed.
+ *
+ * Returns: pointer to a new mutex if successful, otherwise NULL.
+ **/
+slock_t *slock_new(void);
+
+/**
+ * slock_free:
+ * @lock                    : pointer to mutex object
+ *
+ * Frees a mutex.
+ **/
+void slock_free(slock_t *lock);
+
+/**
+ * slock_lock:
+ * @lock                    : pointer to mutex object
+ *
+ * Locks a mutex. If a mutex is already locked by
+ * another thread, the calling thread shall block until
+ * the mutex becomes available.
+**/
+void slock_lock(slock_t *lock);
+
+/**
+ * slock_try_lock:
+ * @lock                    : pointer to mutex object
+ *
+ * Attempts to lock a mutex. If a mutex is already locked by
+ * another thread, return false.  If the lock is acquired, return true.
+**/
+bool slock_try_lock(slock_t *lock);
+
+/**
+ * slock_unlock:
+ * @lock                    : pointer to mutex object
+ *
+ * Unlocks a mutex.
+ **/
+void slock_unlock(slock_t *lock);
+
+/**
+ * scond_new:
+ *
+ * Creates and initializes a condition variable. Must
+ * be manually freed.
+ *
+ * Returns: pointer to new condition variable on success,
+ * otherwise NULL.
+ **/
+scond_t *scond_new(void);
+
+/**
+ * scond_free:
+ * @cond                    : pointer to condition variable object
+ *
+ * Frees a condition variable.
+**/
+void scond_free(scond_t *cond);
+
+/**
+ * scond_wait:
+ * @cond                    : pointer to condition variable object
+ * @lock                    : pointer to mutex object
+ *
+ * Block on a condition variable (i.e. wait on a condition).
+ **/
+void scond_wait(scond_t *cond, slock_t *lock);
+
+/**
+ * scond_wait_timeout:
+ * @cond                    : pointer to condition variable object
+ * @lock                    : pointer to mutex object
+ * @timeout_us              : timeout (in microseconds)
+ *
+ * Try to block on a condition variable (i.e. wait on a condition) until
+ * @timeout_us elapses.
+ *
+ * Returns: false (0) if timeout elapses before condition variable is
+ * signaled or broadcast, otherwise true (1).
+ **/
+bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us);
+
+/**
+ * scond_broadcast:
+ * @cond                    : pointer to condition variable object
+ *
+ * Broadcast a condition. Unblocks all threads currently blocked
+ * on the specified condition variable @cond.
+ **/
+int scond_broadcast(scond_t *cond);
+
+/**
+ * scond_signal:
+ * @cond                    : pointer to condition variable object
+ *
+ * Signal a condition. Unblocks at least one of the threads currently blocked
+ * on the specified condition variable @cond.
+ **/
+void scond_signal(scond_t *cond);
+
+#ifdef HAVE_THREAD_STORAGE
+/**
+ * @brief Creates a thread local storage key
+ *
+ * This function shall create thread-specific data key visible to all threads in
+ * the process. The same key can be used by multiple threads to store
+ * thread-local data.
+ *
+ * When the key is created NULL shall be associated with it in all active
+ * threads. Whenever a new thread is spawned the all defined keys will be
+ * associated with NULL on that thread.
+ *
+ * @param tls
+ * @return whether the operation suceeded or not
+ */
+bool sthread_tls_create(sthread_tls_t *tls);
+
+/**
+ * @brief Deletes a thread local storage
+ * @param tls
+ * @return whether the operation suceeded or not
+ */
+bool sthread_tls_delete(sthread_tls_t *tls);
+
+/**
+ * @brief Retrieves thread specific data associated with a key
+ *
+ * There is no way to tell whether this function failed.
+ *
+ * @param tls
+ * @return
+ */
+void *sthread_tls_get(sthread_tls_t *tls);
+
+/**
+ * @brief Binds thread specific data to a key
+ * @param tls
+ * @return Whether the operation suceeded or not
+ */
+bool sthread_tls_set(sthread_tls_t *tls, const void *data);
+#endif
+
+/*
+ * @brief Get thread ID of specified thread
+ * @param thread
+ * @return The ID of the specified thread
+ */
+uintptr_t sthread_get_thread_id(sthread_t *thread);
+
+/*
+ * @brief Get thread ID of the current thread
+ * @param 
+ * @return The ID of the current thread
+ */
+uintptr_t sthread_get_current_thread_id(void);
+
+RETRO_END_DECLS
+
+#endif

--- a/libretro-common/rthreads/ctr_pthread.h
+++ b/libretro-common/rthreads/ctr_pthread.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2018 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (gx_pthread.h).
@@ -30,14 +30,120 @@
 #include <errno.h>
 #include <retro_inline.h>
 
-#define STACKSIZE (4 * 1024)
+#define STACKSIZE (32 * 1024)
+
+#ifndef PTHREAD_SCOPE_PROCESS
+/* An earlier version of devkitARM does not define the pthread types. Can remove in r54+. */
 
 typedef Thread     pthread_t;
 typedef LightLock  pthread_mutex_t;
 typedef void*      pthread_mutexattr_t;
 typedef int        pthread_attr_t;
-typedef LightEvent pthread_cond_t;
+typedef uint32_t   pthread_cond_t;
 typedef int        pthread_condattr_t;
+#endif
+
+#ifndef USE_CTRULIB_2
+/* Backported CondVar API from libctru 2.0, and under its license:
+   https://github.com/devkitPro/libctru
+   Slightly modified for compatibility with older libctru. */
+
+typedef s32 CondVar;
+
+static INLINE Result syncArbitrateAddress(s32* addr, ArbitrationType type, s32 value)
+{
+   return svcArbitrateAddress(__sync_get_arbiter(), (u32)addr, type, value, 0);
+}
+
+static INLINE Result syncArbitrateAddressWithTimeout(s32* addr, ArbitrationType type, s32 value, s64 timeout_ns)
+{
+   return svcArbitrateAddress(__sync_get_arbiter(), (u32)addr, type, value, timeout_ns);
+}
+
+static INLINE void __dmb(void)
+{
+	__asm__ __volatile__("mcr p15, 0, %[val], c7, c10, 5" :: [val] "r" (0) : "memory");
+}
+
+static INLINE void CondVar_BeginWait(CondVar* cv, LightLock* lock)
+{
+	s32 val;
+	do
+		val = __ldrex(cv) - 1;
+	while (__strex(cv, val));
+	LightLock_Unlock(lock);
+}
+
+static INLINE bool CondVar_EndWait(CondVar* cv, s32 num_threads)
+{
+	bool hasWaiters;
+	s32 val;
+
+	do {
+		val = __ldrex(cv);
+		hasWaiters = val < 0;
+		if (hasWaiters)
+		{
+			if (num_threads < 0)
+				val = 0;
+			else if (val <= -num_threads)
+				val += num_threads;
+			else
+				val = 0;
+		}
+	} while (__strex(cv, val));
+
+	return hasWaiters;
+}
+
+static INLINE void CondVar_Init(CondVar* cv)
+{
+	*cv = 0;
+}
+
+static INLINE void CondVar_Wait(CondVar* cv, LightLock* lock)
+{
+	CondVar_BeginWait(cv, lock);
+	syncArbitrateAddress(cv, ARBITRATION_WAIT_IF_LESS_THAN, 0);
+	LightLock_Lock(lock);
+}
+
+static INLINE int CondVar_WaitTimeout(CondVar* cv, LightLock* lock, s64 timeout_ns)
+{
+	CondVar_BeginWait(cv, lock);
+
+	bool timedOut = false;
+	Result rc = syncArbitrateAddressWithTimeout(cv, ARBITRATION_WAIT_IF_LESS_THAN_TIMEOUT, 0, timeout_ns);
+	if (R_DESCRIPTION(rc) == RD_TIMEOUT)
+	{
+		timedOut = CondVar_EndWait(cv, 1);
+		__dmb();
+	}
+
+	LightLock_Lock(lock);
+	return timedOut;
+}
+
+static INLINE void CondVar_WakeUp(CondVar* cv, s32 num_threads)
+{
+	__dmb();
+	if (CondVar_EndWait(cv, num_threads))
+		syncArbitrateAddress(cv, ARBITRATION_SIGNAL, num_threads);
+	else
+		__dmb();
+}
+
+static INLINE void CondVar_Signal(CondVar* cv)
+{
+	CondVar_WakeUp(cv, 1);
+}
+
+static INLINE void CondVar_Broadcast(CondVar* cv)
+{
+	CondVar_WakeUp(cv, ARBITRATION_SIGNAL_ALL);
+}
+/* End libctru 2.0 backport */
+#endif
 
 /* libctru threads return void but pthreads return void pointer */
 static bool mutex_inited = false;
@@ -56,40 +162,47 @@ static INLINE int pthread_create(pthread_t *thread,
 {
    s32 prio = 0;
    Thread new_ctr_thread;
-      
+   int procnum = -2; // use default cpu
+   bool isNew3DS;
+
+   APT_CheckNew3DS(&isNew3DS);
+
+   if (isNew3DS)
+      procnum = 2;
+
    if (!mutex_inited)
    {
-	   LightLock_Init(&safe_double_thread_launch);
-	   mutex_inited = true;
+      LightLock_Init(&safe_double_thread_launch);
+      mutex_inited = true;
    }
-   
+
    /*Must wait if attempting to launch 2 threads at once to prevent corruption of function pointer*/
    while (LightLock_TryLock(&safe_double_thread_launch) != 0);
-   
+
    svcGetThreadPriority(&prio, CUR_THREAD_HANDLE);
-   
+
    start_routine_jump = start_routine;
-   new_ctr_thread     = threadCreate(ctr_thread_launcher, arg, STACKSIZE, prio - 1, -1/*No affinity, use any CPU*/, false);
-   
+   new_ctr_thread     = threadCreate(ctr_thread_launcher, arg, STACKSIZE, prio - 1, procnum, false);
+
    if (!new_ctr_thread)
    {
-	   LightLock_Unlock(&safe_double_thread_launch);
-	   return EAGAIN;
+      LightLock_Unlock(&safe_double_thread_launch);
+      return EAGAIN;
    }
-   
-   *thread = new_ctr_thread;
+
+   *thread = (pthread_t)new_ctr_thread;
    return 0;
 }
 
 static INLINE pthread_t pthread_self(void)
 {
-   return threadGetCurrent();
+   return (pthread_t)threadGetCurrent();
 }
 
 static INLINE int pthread_mutex_init(pthread_mutex_t *mutex,
       const pthread_mutexattr_t *attr)
 {
-   LightLock_Init(mutex);
+   LightLock_Init((LightLock *)mutex);
    return 0;
 }
 
@@ -101,12 +214,13 @@ static INLINE int pthread_mutex_destroy(pthread_mutex_t *mutex)
 
 static INLINE int pthread_mutex_lock(pthread_mutex_t *mutex)
 {
-   return LightLock_TryLock(mutex);
+   LightLock_Lock((LightLock *)mutex);
+   return 0;
 }
 
 static INLINE int pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
-   LightLock_Unlock(mutex);
+   LightLock_Unlock((LightLock *)mutex);
    return 0;
 }
 
@@ -115,80 +229,95 @@ static INLINE void pthread_exit(void *retval)
    /*Yes the pointer to int cast is not ideal*/
    /*threadExit((int)retval);*/
    (void)retval;
+
+   threadExit(0);
 }
 
 static INLINE int pthread_detach(pthread_t thread)
 {
-   /* FIXME: pthread_detach equivalent missing? */
-   (void)thread;
+   threadDetach((Thread)thread);
    return 0;
 }
 
 static INLINE int pthread_join(pthread_t thread, void **retval)
 {
    /*retval is ignored*/
-   return threadJoin(thread, U64_MAX);
+   if(threadJoin((Thread)thread, INT64_MAX))
+      return -1;
+
+   threadFree((Thread)thread);
+
+   return 0;
 }
 
 static INLINE int pthread_mutex_trylock(pthread_mutex_t *mutex)
 {
-   return LightLock_TryLock(mutex);
+   return LightLock_TryLock((LightLock *)mutex);
 }
 
 static INLINE int pthread_cond_wait(pthread_cond_t *cond,
       pthread_mutex_t *mutex)
 {
-   LightEvent_Wait(cond);
+   CondVar_Wait((CondVar *)cond, (LightLock *)mutex);
    return 0;
 }
 
 static INLINE int pthread_cond_timedwait(pthread_cond_t *cond,
       pthread_mutex_t *mutex, const struct timespec *abstime)
 {
-   while (true)
-   {
-       struct timespec now = {0};
-	    /* Missing clock_gettime*/
-       struct timeval tm;
-      
-       gettimeofday(&tm, NULL);
-       now.tv_sec = tm.tv_sec;
-       now.tv_nsec = tm.tv_usec * 1000;
-       if (LightEvent_TryWait(cond) != 0 || now.tv_sec > abstime->tv_sec || (now.tv_sec == abstime->tv_sec && now.tv_nsec > abstime->tv_nsec))
-		   break;
-   }
-	
-   return 0;
+   struct timespec now = {0};
+   /* Missing clock_gettime*/
+   struct timeval tm;
+   int retval = 0;
+
+   do {
+      gettimeofday(&tm, NULL);
+      now.tv_sec = tm.tv_sec;
+      now.tv_nsec = tm.tv_usec * 1000;
+      s64 timeout = (abstime->tv_sec - now.tv_sec) * 1000000000 + (abstime->tv_nsec - now.tv_nsec);
+
+      if (timeout < 0)
+      {
+         retval = ETIMEDOUT;
+         break;
+      }
+
+      if (!CondVar_WaitTimeout((CondVar *)cond, (LightLock *)mutex, timeout)) {
+         break;
+      }
+   } while (1);
+
+   return retval;
 }
 
 static INLINE int pthread_cond_init(pthread_cond_t *cond,
       const pthread_condattr_t *attr)
 {
-   LightEvent_Init(cond, RESET_ONESHOT);
+   CondVar_Init((CondVar *)cond);
    return 0;
 }
 
 static INLINE int pthread_cond_signal(pthread_cond_t *cond)
 {
-   LightEvent_Signal(cond);
+   CondVar_Signal((CondVar *)cond);
    return 0;
 }
 
 static INLINE int pthread_cond_broadcast(pthread_cond_t *cond)
 {
-   LightEvent_Signal(cond);
+   CondVar_Broadcast((CondVar *)cond);
    return 0;
 }
 
 static INLINE int pthread_cond_destroy(pthread_cond_t *cond)
 {
-   /*nothing to destroy*/
+   /*Nothing to destroy*/
    return 0;
 }
 
 static INLINE int pthread_equal(pthread_t t1, pthread_t t2)
 {
-	if (threadGetHandle(t1) == threadGetHandle(t2))
+	if (threadGetHandle((Thread)t1) == threadGetHandle((Thread)t2))
 		return 1;
 	return 0;
 }

--- a/libretro-common/rthreads/gx_pthread.h
+++ b/libretro-common/rthreads/gx_pthread.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2018 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (gx_pthread.h).
@@ -84,10 +84,13 @@
 
 typedef OSThread pthread_t;
 typedef mutex_t pthread_mutex_t;
+typedef OSCond pthread_cond_t;
+
+#if defined(GX_PTHREAD_LEGACY)
 typedef void* pthread_mutexattr_t;
 typedef int pthread_attr_t;
-typedef OSCond pthread_cond_t;
 typedef OSCond pthread_condattr_t;
+#endif
 
 static INLINE int pthread_create(pthread_t *thread,
       const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg)

--- a/libretro-common/rthreads/psp_pthread.h
+++ b/libretro-common/rthreads/psp_pthread.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2017 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (psp_pthread.h).
@@ -61,7 +61,6 @@ typedef struct
    void* arg;
    sthreadEntry start_routine;
 } sthread_args_struct;
-
 
 static int psp_thread_wrap(SceSize args, void *argp)
 {
@@ -136,7 +135,6 @@ static INLINE int pthread_mutex_unlock(pthread_mutex_t *mutex)
    return 1;
 #endif
 }
-
 
 static INLINE int pthread_join(pthread_t thread, void **retval)
 {
@@ -238,7 +236,6 @@ static INLINE int pthread_cond_init(pthread_cond_t *cond,
 
    return 0;
 
-
 #else
    /* FIXME: stub */
    return 1;
@@ -281,7 +278,6 @@ static INLINE int pthread_cond_destroy(pthread_cond_t *cond)
   return 1;
 #endif
 }
-
 
 static INLINE int pthread_detach(pthread_t thread)
 {

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2018 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (rthreads.c).
@@ -27,6 +27,7 @@
 #endif
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <boolean.h>
 #include <rthreads/rthreads.h>
@@ -49,15 +50,12 @@
 #include "gx_pthread.h"
 #elif defined(_3DS)
 #include "ctr_pthread.h"
-#elif defined(__CELLOS_LV2__)
-#include <pthread.h>
-#include <sys/sys_time.h>
 #else
 #include <pthread.h>
 #include <time.h>
 #endif
 
-#if defined(VITA) || defined(BSD)
+#if defined(VITA) || defined(BSD) || defined(ORBIS)
 #include <sys/time.h>
 #endif
 
@@ -94,9 +92,9 @@ struct slock
 #ifdef USE_WIN32_THREADS
 /* The syntax we'll use is mind-bending unless we use a struct. Plus, we might want to store more info later */
 /* This will be used as a linked list immplementing a queue of waiting threads */
-struct QueueEntry
+struct queue_entry
 {
-   struct QueueEntry *next;
+   struct queue_entry *next;
 };
 #endif
 
@@ -116,7 +114,7 @@ struct scond
    HANDLE event;
 
    /* the head of the queue; NULL if queue is empty */
-   struct QueueEntry *head;
+   struct queue_entry *head;
 
    /* equivalent to the queue length */
    int waiters;
@@ -159,38 +157,91 @@ static void *thread_wrap(void *data_)
  */
 sthread_t *sthread_create(void (*thread_func)(void*), void *userdata)
 {
+	return sthread_create_with_priority(thread_func, userdata, 0);
+}
+
+/* TODO/FIXME - this needs to be implemented for Switch/3DS */
+#if !defined(SWITCH) && !defined(USE_WIN32_THREADS) && !defined(_3DS) && !defined(GEKKO) && !defined(__HAIKU__) && !defined(EMSCRIPTEN)
+#define HAVE_THREAD_ATTR
+#endif
+
+/**
+ * sthread_create_with_priority:
+ * @start_routine           : thread entry callback function
+ * @userdata                : pointer to userdata that will be made
+ *                            available in thread entry callback function
+ * @thread_priority         : thread priority hint value from [1-100]
+ *
+ * Create a new thread. It is possible for the caller to give a hint
+ * for the thread's priority from [1-100]. Any passed in @thread_priority
+ * values that are outside of this range will cause sthread_create() to
+ * create a new thread using the operating system's default thread
+ * priority.
+ *
+ * Returns: pointer to new thread if successful, otherwise NULL.
+ */
+sthread_t *sthread_create_with_priority(void (*thread_func)(void*), void *userdata, int thread_priority)
+{
+#ifdef HAVE_THREAD_ATTR
+   pthread_attr_t thread_attr;
+   bool thread_attr_needed  = false;
+#endif
    bool thread_created      = false;
    struct thread_data *data = NULL;
-   sthread_t *thread        = (sthread_t*)calloc(1, sizeof(*thread));
+   sthread_t *thread        = (sthread_t*)malloc(sizeof(*thread));
 
    if (!thread)
       return NULL;
 
-   data                     = (struct thread_data*)calloc(1, sizeof(*data));
+   data                     = (struct thread_data*)malloc(sizeof(*data));
    if (!data)
       goto error;
 
-   data->func = thread_func;
-   data->userdata = userdata;
+   data->func               = thread_func;
+   data->userdata           = userdata;
 
 #ifdef USE_WIN32_THREADS
-   thread->thread = CreateThread(NULL, 0, thread_wrap, data, 0, &thread->id);
-   thread_created = !!thread->thread;
+   thread->id               = 0;
+   thread->thread           = CreateThread(NULL, 0, thread_wrap,
+         data, 0, &thread->id);
+   thread_created           = !!thread->thread;
 #else
-#if defined(VITA)
-   pthread_attr_t thread_attr;
+   thread->id               = 0;
+
+#ifdef HAVE_THREAD_ATTR
    pthread_attr_init(&thread_attr);
+
+   if ((thread_priority >= 1) && (thread_priority <= 100))
+   {
+      struct sched_param sp;
+      memset(&sp, 0, sizeof(struct sched_param));
+      sp.sched_priority = thread_priority;
+      pthread_attr_setschedpolicy(&thread_attr, SCHED_RR);
+      pthread_attr_setschedparam(&thread_attr, &sp);
+
+      thread_attr_needed = true;
+   }
+#endif
+
+#if defined(VITA)
    pthread_attr_setstacksize(&thread_attr , 0x10000 );
-   thread_created = pthread_create(&thread->id, &thread_attr, thread_wrap, data) == 0;
-#else
-   thread_created = pthread_create(&thread->id, NULL, thread_wrap, data) == 0;
+   thread_attr_needed = true;
+#endif
+
+#ifdef HAVE_THREAD_ATTR
+   if (thread_attr_needed)
+      thread_created = pthread_create(&thread->id, &thread_attr, thread_wrap, data) == 0;
+   else
+#endif
+      thread_created = pthread_create(&thread->id, NULL, thread_wrap, data) == 0;
+
+#ifdef HAVE_THREAD_ATTR
+   pthread_attr_destroy(&thread_attr);
 #endif
 #endif
 
-   if (!thread_created)
-      goto error;
-
-   return thread;
+   if (thread_created)
+      return thread;
 
 error:
    if (data)
@@ -217,7 +268,9 @@ int sthread_detach(sthread_t *thread)
    free(thread);
    return 0;
 #else
-   return pthread_detach(thread->id);
+   int ret = pthread_detach(thread->id);
+   free(thread);
+   return ret;
 #endif
 }
 
@@ -279,11 +332,12 @@ slock_t *slock_new(void)
    if (!lock)
       return NULL;
 
+
 #ifdef USE_WIN32_THREADS
    InitializeCriticalSection(&lock->lock);
-   mutex_created = true;
+   mutex_created             = true;
 #else
-   mutex_created = (pthread_mutex_init(&lock->lock, NULL) == 0);
+   mutex_created             = (pthread_mutex_init(&lock->lock, NULL) == 0);
 #endif
 
    if (!mutex_created)
@@ -335,6 +389,24 @@ void slock_lock(slock_t *lock)
 }
 
 /**
+ * slock_try_lock:
+ * @lock                    : pointer to mutex object
+ *
+ * Attempts to lock a mutex. If a mutex is already locked by
+ * another thread, return false.  If the lock is acquired, return true.
+**/
+bool slock_try_lock(slock_t *lock)
+{
+   if (!lock)
+      return false;
+#ifdef USE_WIN32_THREADS
+   return TryEnterCriticalSection(&lock->lock);
+#else
+   return pthread_mutex_trylock(&lock->lock)==0;
+#endif
+}
+
+/**
  * slock_unlock:
  * @lock                    : pointer to mutex object
  *
@@ -368,7 +440,6 @@ scond_t *scond_new(void)
       return NULL;
 
 #ifdef USE_WIN32_THREADS
-
    /* This is very complex because recreating condition variable semantics
     * with Win32 parts is not easy.
     *
@@ -394,9 +465,10 @@ scond_t *scond_new(void)
     *
     * Note: We might could simplify this using vista+ condition variables,
     * but we wanted an XP compatible solution. */
-   cond->event = CreateEvent(NULL, FALSE, FALSE, NULL);
-   if (!cond->event) goto error;
-   cond->hot_potato = CreateEvent(NULL, FALSE, FALSE, NULL);
+   cond->event             = CreateEvent(NULL, FALSE, FALSE, NULL);
+   if (!cond->event)
+      goto error;
+   cond->hot_potato        = CreateEvent(NULL, FALSE, FALSE, NULL);
    if (!cond->hot_potato)
    {
       CloseHandle(cond->event);
@@ -404,9 +476,6 @@ scond_t *scond_new(void)
    }
 
    InitializeCriticalSection(&cond->cs);
-   cond->waiters = cond->wakens = 0;
-   cond->head = NULL;
-
 #else
    if (pthread_cond_init(&cond->cond, NULL) != 0)
       goto error;
@@ -443,8 +512,8 @@ void scond_free(scond_t *cond)
 #ifdef USE_WIN32_THREADS
 static bool _scond_wait_win32(scond_t *cond, slock_t *lock, DWORD dwMilliseconds)
 {
-   struct QueueEntry myentry;
-   struct QueueEntry **ptr;
+   struct queue_entry myentry;
+   struct queue_entry **ptr;
 
 #if _WIN32_WINNT >= 0x0500 || defined(_XBOX)
    static LARGE_INTEGER performanceCounterFrequency;
@@ -590,7 +659,7 @@ static bool _scond_wait_win32(scond_t *cond, slock_t *lock, DWORD dwMilliseconds
          {
             /* It's not our turn and we're out of time. Give up.
              * Remove ourself from the queue and bail. */
-            struct QueueEntry* curr = cond->head;
+            struct queue_entry *curr = cond->head;
 
             while (curr->next != &myentry)
                curr = curr->next;
@@ -792,14 +861,18 @@ bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us)
    mach_port_deallocate(mach_task_self(), cclock);
    now.tv_sec = mts.tv_sec;
    now.tv_nsec = mts.tv_nsec;
-#elif defined(__CELLOS_LV2__)
+#elif !defined(__PSL1GHT__) && defined(__PS3__)
    sys_time_sec_t s;
    sys_time_nsec_t n;
 
    sys_time_get_current_time(&s, &n);
    now.tv_sec  = s;
    now.tv_nsec = n;
-#elif defined(__mips__) || defined(VITA) || defined(_3DS)
+#elif defined(PS2)
+   int tickms = ps2_clock();
+   now.tv_sec = tickms/1000;
+   now.tv_nsec = tickms * 1000;
+#elif !defined(DINGUX_BETA) && (defined(__mips__) || defined(VITA) || defined(_3DS))
    struct timeval tm;
 
    gettimeofday(&tm, NULL);
@@ -866,3 +939,19 @@ bool sthread_tls_set(sthread_tls_t *tls, const void *data)
 #endif
 }
 #endif
+
+uintptr_t sthread_get_thread_id(sthread_t *thread)
+{
+   if (!thread)
+      return 0;
+   return (uintptr_t)thread->id;
+}
+
+uintptr_t sthread_get_current_thread_id(void)
+{
+#ifdef USE_WIN32_THREADS
+   return (uintptr_t)GetCurrentThreadId();
+#else
+   return (uintptr_t)pthread_self();
+#endif
+}

--- a/libretro-common/rthreads/xenon_sdl_threads.c
+++ b/libretro-common/rthreads/xenon_sdl_threads.c
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2018 The RetroArch team
+/* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (xenon_sdl_threads.c).
@@ -56,4 +56,3 @@ int SDL_CondSignal(SDL_cond *cond)
    *(volatile bool*)cond = false;
    return 0;
 }
-

--- a/libretro_core_options.c
+++ b/libretro_core_options.c
@@ -454,7 +454,7 @@ libretro_set_core_options(void)
   if (!retro_environment_cb)
     return;
 
-  if (retro_environment_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+  if (retro_environment_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
     {
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;

--- a/opera_lr_dsp_threaded.ic
+++ b/opera_lr_dsp_threaded.ic
@@ -4,8 +4,7 @@
 
 #include "bool.h"
 
-#include <pthread.h>
-#include <semaphore.h>
+#include <rthreads/rthreads.h>
 #include <stdint.h>
 
 /* FORWARD DECLARATIONS */
@@ -13,18 +12,21 @@ static void dsp_process(void);
 static void dsp_upload_unlocked(void);
 
 /* MACROS */
-#define DSP_BUF_SIZE      1024
-#define DSP_BUF_SIZE_MASK 0x3FF
+#define DSP_BUF_SIZE      (1 << 12)
+#define DSP_BUF_SIZE_MASK (DSP_BUF_SIZE - 1)
 
 /* GLOBAL VARIABLES */
 static bool_t g_DSP_THREADED = FALSE;
 
-static uint32_t g_DSP_BUF_IDX = 0;
+static uint32_t g_DSP_BUF_IDX     = 0;
+static uint32_t g_DSP_BUF_PENDING = 0;
 static int32_t  g_DSP_BUF[DSP_BUF_SIZE];
 
-static sem_t g_DSP_SEM;
-static pthread_t g_DSP_THREAD;
-static pthread_mutex_t g_DSP_BUF_MUTEX = PTHREAD_MUTEX_INITIALIZER;
+static scond_t *g_DSP_COND         = NULL;
+static slock_t *g_DSP_COND_MUTEX   = NULL;
+static sthread_t *g_DSP_THREAD     = NULL;
+static bool g_DSP_THREAD_RUNNING   = FALSE;
+static slock_t *g_DSP_THREAD_MUTEX = NULL;
 
 static void (*g_DSP_UPLOAD)(void)  = dsp_upload_unlocked;
 static void (*g_DSP_PROCESS)(void) = dsp_process;
@@ -33,24 +35,38 @@ static void (*g_DSP_PROCESS)(void) = dsp_process;
 /* PRIVATE FUNCTIONS */
 
 static
-void *
+void
 dsp_thread_loop(void *handle_)
 {
   int32_t sample;
+  uint32_t pending;
+  bool running = TRUE;
 
-  for(;;)
+  while(running)
     {
-      sem_wait(&g_DSP_SEM);
+      slock_lock(g_DSP_THREAD_MUTEX);
+      running           = g_DSP_THREAD_RUNNING;
+      pending           = g_DSP_BUF_PENDING;
+      g_DSP_BUF_PENDING = 0;
+      slock_unlock(g_DSP_THREAD_MUTEX);
 
-      sample = opera_dsp_loop();
+      if (running)
+        scond_wait(g_DSP_COND, g_DSP_COND_MUTEX);
 
-      pthread_mutex_lock(&g_DSP_BUF_MUTEX);
-      g_DSP_BUF[g_DSP_BUF_IDX++] = sample;
-      g_DSP_BUF_IDX &= DSP_BUF_SIZE_MASK;
-      pthread_mutex_unlock(&g_DSP_BUF_MUTEX);
+      while (pending > 0)
+        {
+          sample = opera_dsp_loop();
+          pending--;
+
+          slock_lock(g_DSP_THREAD_MUTEX);
+          g_DSP_BUF[g_DSP_BUF_IDX++]  = sample;
+          g_DSP_BUF_IDX              &= DSP_BUF_SIZE_MASK;
+          running                     = g_DSP_THREAD_RUNNING;
+          pending                    += g_DSP_BUF_PENDING;
+          g_DSP_BUF_PENDING           = 0;
+          slock_unlock(g_DSP_THREAD_MUTEX);
+        }
     }
-
-  return NULL;
 }
 
 static
@@ -65,11 +81,9 @@ static
 void
 dsp_upload_locked(void)
 {
-  pthread_mutex_lock(&g_DSP_BUF_MUTEX);
-
+  slock_lock(g_DSP_THREAD_MUTEX);
   dsp_upload_unlocked();
-
-  pthread_mutex_unlock(&g_DSP_BUF_MUTEX);
+  slock_unlock(g_DSP_THREAD_MUTEX);
 }
 
 static
@@ -84,7 +98,11 @@ static
 void
 dsp_process_threaded(void)
 {
-  sem_post(&g_DSP_SEM);
+  slock_lock(g_DSP_THREAD_MUTEX);
+  g_DSP_BUF_PENDING++;
+  slock_unlock(g_DSP_THREAD_MUTEX);
+
+  scond_signal(g_DSP_COND);
 }
 
 
@@ -105,13 +123,25 @@ opera_lr_dsp_upload(void)
 void
 opera_lr_dsp_destroy(void)
 {
-  void *rv;
-
   if(g_DSP_THREADED)
     {
-      pthread_cancel(g_DSP_THREAD);
-      pthread_join(g_DSP_THREAD,&rv);
-      sem_destroy(&g_DSP_SEM);
+      slock_lock(g_DSP_THREAD_MUTEX);
+      g_DSP_THREAD_RUNNING = FALSE;
+      g_DSP_BUF_PENDING    = 0;
+      g_DSP_BUF_IDX        = 0;
+      slock_unlock(g_DSP_THREAD_MUTEX);
+
+      scond_signal(g_DSP_COND);
+      sthread_join(g_DSP_THREAD);
+
+      scond_free(g_DSP_COND);
+      slock_free(g_DSP_COND_MUTEX);
+      slock_free(g_DSP_THREAD_MUTEX);
+
+      g_DSP_THREAD       = NULL;
+      g_DSP_COND         = NULL;
+      g_DSP_COND_MUTEX   = NULL;
+      g_DSP_THREAD_MUTEX = NULL;
     }
 }
 
@@ -128,10 +158,14 @@ opera_lr_dsp_init(const bool_t threaded_)
   g_DSP_THREADED = threaded_;
   if(g_DSP_THREADED)
     {
-      sem_init(&g_DSP_SEM,0,0);
-      pthread_create(&g_DSP_THREAD,NULL,dsp_thread_loop,NULL);
-      g_DSP_UPLOAD  = dsp_upload_locked;
-      g_DSP_PROCESS = dsp_process_threaded;
+      g_DSP_COND           = scond_new();
+      g_DSP_COND_MUTEX     = slock_new();
+      g_DSP_THREAD_MUTEX   = slock_new();
+      g_DSP_THREAD_RUNNING = TRUE;
+      g_DSP_THREAD         = sthread_create(dsp_thread_loop, NULL);
+
+      g_DSP_UPLOAD         = dsp_upload_locked;
+      g_DSP_PROCESS        = dsp_process_threaded;
     }
   else
     {


### PR DESCRIPTION
At present, the `Threaded DSP` option does not work correctly. Each call of `dsp_process_threaded()` should produce one iteration of `opera_dsp_loop()` - but this is not the case. Due to the way that the main and DSP threads are synchronised, multiple calls of `dsp_process_threaded()` may occur (and be ignored) while `opera_dsp_loop()` is running, resulting in missing samples and severely distorted audio.

This PR fixes the issue, by ensuring that `opera_dsp_loop()` is called the correct number of times. It also switches the code from pthreads to rthreads - which means the `Threaded DSP` option is now available on all platforms apart from emscriptem.

Finally, the PR also fixes a trivial bug in `libretro_core_options.c` which meant core options v1 support was mistakenly disabled (i.e. current master has no core option sublabels)