### PR TITLE
Allow offscreen reloading on all 4 sides of screen

### DIFF
--- a/lr_input.c
+++ b/lr_input.c
@@ -149,6 +149,12 @@ lr_input_poll_lightgun(const int port_)
   lg.trigger = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_TRIGGER);
   lg.option  = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_SELECT);
   lg.reload  = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_RELOAD);
+            
+  if(poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN))
+  {
+    lg.trigger = 0;
+    lg.reload  = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_TRIGGER) || poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_RELOAD);
+  }
 
   lr_input_crosshair_set(port_,lg.x,lg.y);
 
@@ -168,6 +174,12 @@ lr_input_poll_arcade_lightgun(const int port_)
   lg.coins   = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_SELECT);
   lg.start   = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_START);
   lg.holster = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_RELOAD);
+            
+  if(poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN))
+  {
+    lg.trigger = 0;
+    lg.holster = poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_TRIGGER) || poll_lightgun(port_,RETRO_DEVICE_ID_LIGHTGUN_RELOAD);
+  }
 
   lr_input_crosshair_set(port_,lg.x,lg.y);
 


### PR DESCRIPTION
Hello,

Currently, many 3DO games only allow lightgun users to shoot off parts of the top of the screen in order to reload. This code change allows lightgun users to fire off any part of any side of the screen to reload in games that have a functioning reload/holster input. It is tested as working with all 3DO lightgun games except for Mad Dog McCree and Space Pirates, which still exhibit the issues outlined in #176, and it is also tested as working with the arcade game Shootout at Old Tucson (which didn't appear to have functioning offscreen reload before this).

I tried investigating the issues outlined in #176, but it seems that there is no place along the screen boundary that consistently acts as an out-of-bounds region for reloading for those two games. The emulator's reload button fires a shot at the middle of the top edge of the screen, which is enough for most games, but it doesn't work for Mad Dog McCree and Space Pirates for some reason.

Further, while testing this code with a friend, we found that 2 lightguns for 2-player games doesn't currently seem possible. I found the note in the code about how the gun acts as player 2, and I wonder if the fact that there are at least two different 3DO gun models is causing this. One model allows daisy chaining with a second gun, and the other only has a single controller plug. Perhaps an alternate device (dual lightguns?) that emulates two guns daisy chained is needed in order to get 2 players working?
