### PR TITLE
Enable second player for SAOT

### DIFF
--- a/libopera/opera_pbus.c
+++ b/libopera/opera_pbus.c
@@ -209,10 +209,10 @@ opera_pbus_add_arcade_lightgun(const opera_pbus_arcade_lightgun_t *lg_)
                           (lg_->service << PBUS_LG_SHIFT_SERVICE) |
                           (lg_->coins   << PBUS_LG_SHIFT_COINS)   |
                           (lg_->start   << PBUS_LG_SHIFT_START)   |
-                          (lg_->holster << PBUS_LG_SHIFT_HOLSTER) |
-                          ((r & 0x10000) >> 16));
+                          (lg_->holster << PBUS_LG_SHIFT_HOLSTER));
   PBUS.buf[PBUS.idx++] = ((r & 0xFF00) >> 8);
   PBUS.buf[PBUS.idx++] = (r & 0xFF);
+  PBUS.buf[PBUS.idx++] = ((r & 0x10000) >> 16);
 }
 
 void


### PR DESCRIPTION
Hello,

As per previous discussion, the lightgun implementation in lr-opera has some issues. However, by rearranging a couple lines of code in the existing arcade-lightgun implementation, I got 2 guns to work properly in Shootout at Old Tucson. Each player can independently aim, add coins, press start, shoot, reload, and access the service menu properly with these changes. Previously, the second gun would interfere with the operation of the first, but that is not the case anymore with these changes.

The calibration menu is a bit misleading. You have to press the button you assigned to Libretro's "Gun Start" input in order to fire a calibration shot. Shooting using the "Gun Trigger" input just tests the calibration. You will likely need to calibrate both players before jumping into a game.

Here are the controls, in case anyone is wondering:

Gun Trigger = shoot
Gun Aux A = toggle service menu and cycle service-menu items
Gun Select = coin
Gun Start = in-game start, select service-menu items, and (during gameplay) switch weapons
Gun Reload = simulated offscreen shot (can also point the gun offscreen and shoot to reload)

I suggest changing the coin options from the default since player 1 (left) has to add multiple coins to get a single credit with the default settings.

An issue that remains is that the port number does not correspond to player number, so port 1 controls player 2 and port 2 controls player 1.

Additionally, these exact same changes do not appear to allow 2 guns to work fully with 3DO games in the 3DO-lightgun implementation, though I do get two independent sets of shots appearing on screen (just can't aim properly). I can investigate that separately. For now, the 3DO portion of the lightgun implementation is unchanged.