### PR TITLE
Core option: hide all lightgun crosshairs

### DIFF
--- a/libretro_core_options.c
+++ b/libretro_core_options.c
@@ -190,6 +190,17 @@ static struct retro_core_option_definition option_defs_us[] =
       "1"
     },
     {
+      "opera_hide_lightgun_crosshairs",
+      "Hide Lightgun Crosshairs",
+      "Hides lightgun crosshairs for all players.",
+      {
+        { "disabled", NULL },
+        { "enabled", NULL },
+        { NULL, NULL },
+      },
+      "disabled"
+    },
+    {
       "opera_hack_timing_1",
       "Timing Hack 1 (Crash 'n Burn)",
       "This must be enabled for correct operation of the game 'Crash 'n Burn'.",

--- a/lr_input_crosshair.c
+++ b/lr_input_crosshair.c
@@ -10,6 +10,7 @@ struct lr_crosshair_s
 };
 
 typedef struct lr_crosshair_s lr_crosshair_t;
+extern uint32_t g_OPT_HIDE_LIGHTGUN_CROSSHAIRS;
 
 static const uint32_t COLORS[LR_INPUT_MAX_DEVICES] =
   {
@@ -88,6 +89,7 @@ lr_input_crosshairs_draw(uint32_t       *buf_,
       if(CROSSHAIRS[i].c == 0)
         continue;
 
-      lr_input_crosshair_draw(&CROSSHAIRS[i],buf_,width_,height_);
+      if(g_OPT_HIDE_LIGHTGUN_CROSSHAIRS == 0)
+        lr_input_crosshair_draw(&CROSSHAIRS[i],buf_,width_,height_);
     }
 }

--- a/opera_lr_opts.c
+++ b/opera_lr_opts.c
@@ -35,12 +35,13 @@
 
 const opera_bios_t *g_OPT_BIOS = NULL;
 const opera_bios_t *g_OPT_FONT = NULL;
-uint32_t g_OPT_VIDEO_WIDTH       = 0;
-uint32_t g_OPT_VIDEO_HEIGHT      = 0;
-uint32_t g_OPT_VIDEO_PITCH_SHIFT = 0;
-uint32_t g_OPT_VDLP_FLAGS        = 0;
-uint32_t g_OPT_VDLP_PIXEL_FORMAT = 0;
-uint32_t g_OPT_ACTIVE_DEVICES    = 0;
+uint32_t g_OPT_VIDEO_WIDTH              = 0;
+uint32_t g_OPT_VIDEO_HEIGHT             = 0;
+uint32_t g_OPT_VIDEO_PITCH_SHIFT        = 0;
+uint32_t g_OPT_VDLP_FLAGS               = 0;
+uint32_t g_OPT_VDLP_PIXEL_FORMAT        = 0;
+uint32_t g_OPT_ACTIVE_DEVICES           = 0;
+uint32_t g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 0;
 
 static
 int
@@ -299,6 +300,21 @@ opera_lr_opts_process_active_devices(void)
 }
 
 void
+opera_lr_opts_process_hide_lightgun_crosshairs(void)
+{
+  bool rv;
+
+  rv = opera_lr_opts_is_enabled("hide_lightgun_crosshairs");
+
+  g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 0;
+
+  if(rv)
+    g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 1;
+  else
+    g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 0;
+}
+
+void
 opera_lr_opts_process_madam_matrix_engine(void)
 {
   const char *val;
@@ -378,6 +394,7 @@ opera_lr_opts_process(void)
   opera_lr_opts_process_cpu_overlock();
   opera_lr_opts_process_dsp_threaded();
   opera_lr_opts_process_active_devices();
+  opera_lr_opts_process_hide_lightgun_crosshairs();
   opera_lr_opts_process_debug();
   opera_lr_opts_process_madam_matrix_engine();
   opera_lr_opts_process_swi_hle();

--- a/opera_lr_opts.h
+++ b/opera_lr_opts.h
@@ -32,6 +32,7 @@ void                 opera_lr_opts_process_vdlp_flags(void);
 void                 opera_lr_opts_process_high_resolution(void);
 void                 opera_lr_opts_process_vdlp_pixel_format(void);
 void                 opera_lr_opts_process_active_devices(void);
+void                 opera_lr_opts_process_hide_lightgun_crosshairs(void);
 void                 opera_lr_opts_process_madam_matrix_engine(void);
 void                 opera_lr_opts_process_debug(void);
 void                 opera_lr_opts_process_dsp_threaded(void);


### PR DESCRIPTION
Re: #186: Adds a toggle to the core options to hide the lightgun crosshairs for all players. Default behavior is to have the core option disabled (i.e., the crosshairs are visible) to mimic the other core options being disabled by default and also to preserve the original default behavior of the crosshairs being visible. Can be toggled on and off without needing to restart the emulator.

Please feel free to make changes as you see fit. I hope that this helps.