### PR TITLE
Rework PRNG and seed with time

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -28,6 +28,7 @@ SOURCES_C := \
         $(CORE_DIR)/retro_cdimage.c \
 
 SOURCES_C += \
+        $(OPERA_DIR)/prng16.c \
         $(OPERA_DIR)/opera_3do.c \
         $(OPERA_DIR)/opera_arm.c \
         $(OPERA_DIR)/opera_bios.c \

--- a/libopera/opera_clio.c
+++ b/libopera/opera_clio.c
@@ -36,6 +36,7 @@
 #include "opera_xbus.h"
 
 #include "boolean.h"
+#include "prng16.h"
 
 #include <string.h>
 
@@ -44,8 +45,6 @@
 #define CASCADE      0x4
 #define FLABLODE     0x8
 #define RELOAD_VAL   0x10
-
-extern int fastrand(void);
 
 struct fifo_s
 {
@@ -618,7 +617,7 @@ opera_clio_peek(uint32_t addr_)
       return opera_dsp_imem_read(CLIO.dsp_address);
     }
   else if(addr_ == 0x17F0)
-    return fastrand();
+    return prng16();
   else if(addr_ == 0x17D0) /* read DSP/ARM semaphore */
     return opera_dsp_arm_semaphore_read();
 

--- a/libopera/prng16.c
+++ b/libopera/prng16.c
@@ -1,0 +1,30 @@
+#include "inline.h"
+
+#include <stdint.h>
+
+static uint32_t g_PRNG16_STATE = 0xDEADBEEF;
+
+static
+INLINE
+uint32_t
+hash16(uint32_t const input_,
+       uint32_t const key_)
+{
+  uint32_t const hash = (input_ * key_);
+
+  return (((hash >> 16) ^ hash) & 0xFFFF);
+}
+
+void
+prng16_seed(uint32_t const seed_)
+{
+  g_PRNG16_STATE = seed_;
+}
+
+uint32_t
+prng16()
+{
+  g_PRNG16_STATE += 0xFC15;
+
+  return hash16(g_PRNG16_STATE,0x02AB);
+}

--- a/libopera/prng16.h
+++ b/libopera/prng16.h
@@ -1,0 +1,9 @@
+#ifndef LIBOPERA_PRNG16_H_INCLUDED
+#define LIBOPERA_PRNG16_H_INCLUDED
+
+#include <stdint.h>
+
+void     prng16_seed(uint32_t const seed);
+uint32_t prng16();
+
+#endif

--- a/libretro.c
+++ b/libretro.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <file/file_path.h>
 #include <libretro.h>
@@ -17,10 +18,11 @@
 #include "libopera/opera_clock.h"
 #include "libopera/opera_core.h"
 #include "libopera/opera_madam.h"
+#include "libopera/opera_nvram.h"
 #include "libopera/opera_pbus.h"
 #include "libopera/opera_region.h"
 #include "libopera/opera_vdlp.h"
-#include "libopera/opera_nvram.h"
+#include "libopera/prng16.h"
 
 #include "opera_lr_dsp.h"
 #include "lr_input.h"
@@ -577,6 +579,8 @@ retro_init(void)
   opera_cdrom_set_callbacks(cdimage_get_size,
                             cdimage_set_sector,
                             cdimage_read_sector);
+
+  prng16_seed(time(NULL));
 }
 
 void


### PR DESCRIPTION
The previous implementation used a fixed seed. For homebrew it may be useful to introduce an option to allow using a fixed seed but for now it is better to add in a more proper PRNG to the DSP.