### PR TITLE
Add memory capacity option

### DIFF
--- a/libopera/opera_3do.c
+++ b/libopera/opera_3do.c
@@ -61,18 +61,16 @@ opera_3do_init(opera_ext_interface_t callback_)
 {
   int i;
 
-  opera_mem_init();
+  if(opera_mem_cfg() == DRAM_VRAM_UNSET)
+    opera_mem_init(DRAM_VRAM_STOCK);
 
   io_interface = callback_;
 
   CNBFIX = 0;
 
-  opera_clock_init();
-
   opera_arm_init();
 
   opera_vdlp_init();
-  opera_sport_init();
   opera_madam_init();
   opera_xbus_init(xbus_cdrom_plugin);
 

--- a/libopera/opera_arm.c
+++ b/libopera/opera_arm.c
@@ -114,12 +114,12 @@ static int        g_SWI_HLE;
 static arm_core_t CPU;
 static int        CYCLES;	//cycle counter
 
-static uint32_t readusr(uint32_t rn);
-static void     loadusr(uint32_t rn, uint32_t val);
-static uint32_t mreadb(uint32_t addr);
-static void     mwriteb(uint32_t addr, uint8_t val);
-static uint32_t mreadw(uint32_t addr);
-static void     mwritew(uint32_t addr,uint32_t val);
+static uint32_t readusr(uint32_t const rn);
+static void     loadusr(uint32_t const rn, uint32_t const val);
+static uint32_t mreadb(uint32_t const addr);
+static void     mwriteb(uint32_t const addr, uint8_t const val);
+static uint32_t mreadw(uint32_t const addr);
+static void     mwritew(uint32_t const addr,uint32_t const val);
 
 uint32_t
 opera_arm_state_size(void)
@@ -1877,8 +1877,8 @@ mreadb(uint32_t const addr_)
 
 static
 void
-loadusr(uint32_t n_,
-        uint32_t val_)
+loadusr(uint32_t const n_,
+        uint32_t const val_)
 {
   if(n_ == 15)
     {
@@ -1911,7 +1911,7 @@ loadusr(uint32_t n_,
 
 static
 uint32_t
-readusr(uint32_t n_)
+readusr(uint32_t const n_)
 {
   if(n_ == 15)
     return CPU.USER[15];

--- a/libopera/opera_clio.c
+++ b/libopera/opera_clio.c
@@ -83,6 +83,13 @@ int TIMER_VAL = 0; //0x415
 static uint32_t *MADAM_REGS;
 static clio_t    CLIO = {0};
 
+static
+void
+opera_clio_set_rom()
+{
+  opera_mem_rom_select((CLIO.regs[0x84] & 0x4) ? ROM2 : ROM1);
+}
+
 uint32_t
 opera_clio_state_size(void)
 {
@@ -98,9 +105,14 @@ opera_clio_state_save(void *buf_)
 uint32_t
 opera_clio_state_load(const void *buf_)
 {
+  uint32_t rv;
+
   TIMER_VAL = 0;
 
-  return opera_state_load(&CLIO,"CLIO",buf_,sizeof(CLIO));
+  rv = opera_state_load(&CLIO,"CLIO",buf_,sizeof(CLIO));
+  opera_clio_set_rom();
+
+  return rv;
 }
 
 #define CURADR MADAM_REGS[base+0x00]
@@ -353,7 +365,7 @@ opera_clio_poke(uint32_t addr_,
       if_set_set_reset(&CLIO.regs[0x84],val_,0x40,0x04);
       if_set_set_reset(&CLIO.regs[0x84],val_,0x80,0x08);
 
-      opera_mem_rom_select((val_ & 0x4) ? ROM2 : ROM1);
+      opera_clio_set_rom();
 
       return 0;
     }

--- a/libopera/opera_clock.h
+++ b/libopera/opera_clock.h
@@ -7,8 +7,6 @@
 
 EXTERN_C_BEGIN
 
-void     opera_clock_init(void);
-
 int      opera_clock_vdl_queued(void);
 int      opera_clock_dsp_queued(void);
 int      opera_clock_timer_queued(void);

--- a/libopera/opera_mem.h
+++ b/libopera/opera_mem.h
@@ -49,6 +49,7 @@ extern uint8_t *ROM2;
 
 enum opera_mem_cfg_t
   {
+    DRAM_VRAM_UNSET    = 0x00,
     DRAM_VRAM_STOCK    = 0x21,
     DRAM_2MB_VRAM_1MB  = 0x21,
     DRAM_2MB_VRAM_2MB  = 0x22,
@@ -61,8 +62,12 @@ enum opera_mem_cfg_t
   };
 typedef enum opera_mem_cfg_t opera_mem_cfg_t;
 
-int  opera_mem_init();
+int  opera_mem_init(opera_mem_cfg_t);
 void opera_mem_destroy();
+
+opera_mem_cfg_t opera_mem_cfg();
+
+uint32_t opera_mem_madam_red_sysbits(uint32_t const);
 
 void opera_mem_rom1_clear();
 void opera_mem_rom1_byteswap32_if_le();
@@ -127,6 +132,21 @@ opera_mem_write8(uint32_t const addr_,
   DRAM[addr + 1*VRAM_SIZE] =
     DRAM[addr + 2*VRAM_SIZE] =
     DRAM[addr + 3*VRAM_SIZE] = val_;
+}
+
+static
+INLINE
+void
+opera_mem_write16_base(uint32_t const addr_,
+                       uint16_t const val_)
+{
+#if IS_BIG_ENDIAN
+  uint32_t const addr = addr_;
+#else
+  uint32_t const addr = (addr_ ^ 2);
+#endif
+
+  *((uint16_t*)&DRAM[addr]) = val_;
 }
 
 static

--- a/libopera/opera_region.c
+++ b/libopera/opera_region.c
@@ -83,6 +83,18 @@ opera_region_get(void)
 }
 
 uint32_t
+opera_region_min_width(void)
+{
+  return NTSC_WIDTH;
+}
+
+uint32_t
+opera_region_min_height(void)
+{
+  return NTSC_HEIGHT;
+}
+
+uint32_t
 opera_region_max_width(void)
 {
   return PAL2_WIDTH;

--- a/libopera/opera_region.h
+++ b/libopera/opera_region.h
@@ -15,6 +15,8 @@ void opera_region_set_PAL2(void);
 
 opera_region_e opera_region_get(void);
 
+uint32_t opera_region_min_width(void);
+uint32_t opera_region_min_height(void);
 uint32_t opera_region_max_width(void);
 uint32_t opera_region_max_height(void);
 

--- a/libopera/opera_vdlp.c
+++ b/libopera/opera_vdlp.c
@@ -31,7 +31,7 @@ static void                *g_BUF          = NULL;
 static void                *g_CURBUF       = NULL;
 static vdlp_renderer_t      g_RENDERER     = NULL;
 static uint32_t             g_FLAGS        = VDLP_FLAG_NONE;
-static vdlp_pixel_format_e  g_PIXEL_FORMAT = VDLP_PIXEL_FORMAT_0RGB1555;
+static vdlp_pixel_format_e  g_PIXEL_FORMAT = VDLP_PIXEL_FORMAT_RGB565;
 
 static const uint32_t PIXELS_PER_LINE_MODULO[8] =
   {320, 384, 512, 640, 1024, 320, 320, 320};
@@ -280,7 +280,9 @@ vdlp_render_line_0RGB1555(void)
   g_CURBUF = &dst[width];
 }
 
-static void vdlp_render_line_0RGB1555_bypass_clut(void)
+static
+void
+vdlp_render_line_0RGB1555_bypass_clut(void)
 {
   int x;
   int width;
@@ -303,7 +305,9 @@ static void vdlp_render_line_0RGB1555_bypass_clut(void)
   g_CURBUF = &dst[width];
 }
 
-static void vdlp_render_line_0RGB1555_hires(void)
+static
+void
+vdlp_render_line_0RGB1555_hires(void)
 {
   int x;
   int width;
@@ -501,7 +505,9 @@ vdlp_render_line_RGB565_bypass_clut(void)
   g_CURBUF = &dst[width];
 }
 
-static void vdlp_render_line_RGB565_hires(void)
+static
+void
+vdlp_render_line_RGB565_hires(void)
 {
   int x;
   int width;
@@ -550,7 +556,9 @@ static void vdlp_render_line_RGB565_hires(void)
   g_CURBUF = dst1;
 }
 
-static void vdlp_render_line_RGB565_hires_bypass_clut(void)
+static
+void
+vdlp_render_line_RGB565_hires_bypass_clut(void)
 {
   int x;
   int width;
@@ -860,7 +868,8 @@ opera_vdlp_init()
     };
 
   g_VDLP.head_vdl = 0xB0000;
-  g_RENDERER = vdlp_render_line_XRGB8888;
+  if(g_RENDERER == NULL)
+    g_RENDERER = vdlp_render_line_RGB565;
 
   for(i = 0; i < (sizeof(StartupVDL)/sizeof(uint32_t)); i++)
     vram_write32((0xB0000 + (i * sizeof(uint32_t))),StartupVDL[i]);
@@ -996,20 +1005,6 @@ opera_vdlp_set_pixel_format(vdlp_pixel_format_e v_)
 
   g_RENDERER     = new_renderer;
   g_PIXEL_FORMAT = v_;
-
-  return 0;
-}
-
-int
-opera_vdlp_configure(void                *buf_,
-                     vdlp_pixel_format_e  pf_,
-                     uint32_t             flags_)
-{
-  g_BUF = buf_;
-
-  g_RENDERER = get_renderer(pf_,flags_);
-  if(g_RENDERER)
-    return -1;
 
   return 0;
 }

--- a/libopera/opera_vdlp.h
+++ b/libopera/opera_vdlp.h
@@ -3,6 +3,8 @@
 
 #include "extern_c.h"
 
+#include "boolean.h"
+
 #include <stdint.h>
 
 #define VDLP_FLAG_NONE          0
@@ -22,18 +24,19 @@ typedef enum vdlp_pixel_format_e vdlp_pixel_format_e;
 
 EXTERN_C_BEGIN
 
-void     opera_vdlp_init();
+void opera_vdlp_init();
 
-void     opera_vdlp_set_vdl_head(const uint32_t addr);
-void     opera_vdlp_process_line(int line);
+void opera_vdlp_set_vdl_head(const uint32_t addr);
+void opera_vdlp_process_line(int line);
 
 uint32_t opera_vdlp_state_size(void);
 uint32_t opera_vdlp_state_save(void *buf);
 uint32_t opera_vdlp_state_load(void const *buf);
 
-int      opera_vdlp_configure(void *buf,
-                              vdlp_pixel_format_e pf,
-                              uint32_t flags);
+int opera_vdlp_set_video_buffer(void* buf);
+int opera_vdlp_set_hires(bool v);
+int opera_vdlp_set_bypass_clut(bool v);
+int opera_vdlp_set_pixel_format(vdlp_pixel_format_e fmt);
 
 EXTERN_C_END
 

--- a/lr_input_crosshair.c
+++ b/lr_input_crosshair.c
@@ -10,7 +10,6 @@ struct lr_crosshair_s
 };
 
 typedef struct lr_crosshair_s lr_crosshair_t;
-extern uint32_t g_OPT_HIDE_LIGHTGUN_CROSSHAIRS;
 
 static const uint32_t COLORS[LR_INPUT_MAX_DEVICES] =
   {
@@ -88,8 +87,6 @@ lr_input_crosshairs_draw(uint32_t       *buf_,
     {
       if(CROSSHAIRS[i].c == 0)
         continue;
-
-      if(g_OPT_HIDE_LIGHTGUN_CROSSHAIRS == 0)
-        lr_input_crosshair_draw(&CROSSHAIRS[i],buf_,width_,height_);
+      lr_input_crosshair_draw(&CROSSHAIRS[i],buf_,width_,height_);
     }
 }

--- a/opera_lr_nvram.c
+++ b/opera_lr_nvram.c
@@ -1,16 +1,18 @@
-#include "compat/strl.h"
-#include "file/file_path.h"
-#include "retro_miscellaneous.h"
-#include "streams/file_stream.h"
+#include <string.h>
+
+#include <compat/strl.h>
+#include <file/file_path.h>
+#include <retro_endianness.h>
+#include <retro_miscellaneous.h>
+#include <streams/file_stream.h>
+
+#include "libopera/opera_arm.h"
+#include "libopera/opera_mem.h"
+#include "libopera/opera_nvram.h"
 
 #include "opera_lr_callbacks.h"
 #include "opera_lr_nvram.h"
 #include "opera_lr_opts.h"
-
-#include "libopera/opera_mem.h"
-#include "libopera/opera_nvram.h"
-
-#include <string.h>
 
 static const char OLD_NVRAM_FILENAME[] = "3DO.nvram";
 
@@ -141,7 +143,7 @@ opera_lr_nvram_save_pergame(const uint8_t *nvram_buf_,
     return -1;
 
   fill_pathname_join(filepath,filepath,"per_game",sizeof(filepath));
-  snprintf(filename,PATH_MAX_LENGTH,"%s.%d.srm",name_,version_);
+  snprintf(filename,PATH_MAX_LENGTH,"%s.%u.srm",name_,version_);
   fill_pathname_join(filepath,filepath,filename,sizeof(filepath));
 
   rv = nvram_save(nvram_buf_,nvram_size_,filepath);
@@ -164,7 +166,7 @@ opera_lr_nvram_save_shared(const uint8_t *nvram_buf_,
     return -1;
 
   fill_pathname_join(filepath,filepath,"shared",sizeof(filepath));
-  snprintf(filename,PATH_MAX_LENGTH,"nvram.%d.srm",version_);
+  snprintf(filename,PATH_MAX_LENGTH,"nvram.%u.srm",version_);
   fill_pathname_join(filepath,filepath,filename,sizeof(filepath));
 
   rv = nvram_save(nvram_buf_,nvram_size_,filepath);
@@ -229,7 +231,7 @@ opera_lr_nvram_load_pergame_operadir(uint8_t       *nvram_buf_,
   if(rv < 0)
     return -1;
 
-  snprintf(filename,sizeof(filename),"%s.%d.srm",name_,version_);
+  snprintf(filename,sizeof(filename),"%s.%u.srm",name_,version_);
   fill_pathname_join(filepath,filepath,"per_game",sizeof(filepath));
   fill_pathname_join(filepath,filepath,filename,sizeof(filepath));
 
@@ -351,57 +353,51 @@ opera_lr_nvram_load_shared(uint8_t       *nvram_buf_,
 */
 
 void
-opera_lr_nvram_save(const char *gamepath_)
+opera_lr_nvram_save(const char    *gamepath_,
+                    const bool     shared_,
+                    const uint8_t  version_)
 {
-  uint8_t version;
-  size_t nvram_size;
-  const uint8_t *nvram_buf;
-
-  nvram_buf  = NVRAM;
-  nvram_size = NVRAM_SIZE;
-  version    = opera_lr_opts_nvram_version();
-  if(opera_lr_opts_is_nvram_shared() || (gamepath_ == NULL))
+  if(shared_ || (gamepath_ == NULL))
     {
-      opera_lr_nvram_save_shared(nvram_buf,nvram_size,version);
+      opera_lr_nvram_save_shared(NVRAM,NVRAM_SIZE,version_);
     }
   else
     {
-      char filename[256];
-      const char *ptr = path_basename(gamepath_);
-      if (ptr)
-         strlcpy(filename, ptr, sizeof(filename));
+      const char *ptr;
+      char filename[PATH_MAX_LENGTH];
+
+      ptr = path_basename(gamepath_);
+      if(ptr)
+        strlcpy(filename,ptr,sizeof(filename));
       else
-	 strlcpy(filename, gamepath_, sizeof(filename));
+        strlcpy(filename,gamepath_,sizeof(filename));
       path_remove_extension(filename);
 
-      opera_lr_nvram_save_pergame(nvram_buf,nvram_size,filename,version);
+      opera_lr_nvram_save_pergame(NVRAM,NVRAM_SIZE,filename,version_);
     }
 }
 
 void
-opera_lr_nvram_load(const char *gamepath_)
+opera_lr_nvram_load(const char    *gamepath_,
+                    const bool     shared_,
+                    const uint8_t  version_)
 {
-  uint8_t   version;
-  uint8_t  *nvram_buf;
-  uint32_t  nvram_size;
-
-  nvram_buf  = NVRAM;
-  nvram_size = NVRAM_SIZE;
-  version    = opera_lr_opts_nvram_version();
-  if(opera_lr_opts_is_nvram_shared() || (gamepath_ == NULL))
+  if(shared_ || (gamepath_ == NULL))
     {
-      opera_lr_nvram_load_shared(nvram_buf,nvram_size,version);
+      opera_lr_nvram_load_shared(NVRAM,NVRAM_SIZE,version_);
     }
   else
     {
-      char filename[256];
-      const char *ptr = path_basename(gamepath_);
-      if (ptr)
-         strlcpy(filename, ptr, sizeof(filename));
+      const char *ptr;
+      char filename[PATH_MAX_LENGTH];
+
+      ptr = path_basename(gamepath_);
+      if(ptr)
+        strlcpy(filename,ptr,sizeof(filename));
       else
-	 strlcpy(filename, gamepath_, sizeof(filename));
+        strlcpy(filename,gamepath_,sizeof(filename));
       path_remove_extension(filename);
 
-      opera_lr_nvram_load_pergame(nvram_buf,nvram_size,filename,version);
+      opera_lr_nvram_load_pergame(NVRAM,NVRAM_SIZE,filename,version_);
     }
 }

--- a/opera_lr_nvram.h
+++ b/opera_lr_nvram.h
@@ -1,7 +1,13 @@
 #ifndef OPERA_LR_NVRAM_H_INCLUDED
 #define OPERA_LR_NVRAM_H_INCLUDED
 
-void opera_lr_nvram_load(const char *gamepath);
-void opera_lr_nvram_save(const char *gamepath);
+#include <stdint.h>
+
+void opera_lr_nvram_load(const char    *gamepath,
+                         const bool     shared_,
+                         const uint8_t  version);
+void opera_lr_nvram_save(const char    *gamepath,
+                         const bool     shared_,
+                         const uint8_t  version);
 
 #endif

--- a/opera_lr_opts.c
+++ b/opera_lr_opts.c
@@ -16,6 +16,8 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#include "opera_lr_opts.h"
+
 #include "opera_lr_callbacks.h"
 #include "opera_lr_dsp.h"
 #include "lr_input.h"
@@ -30,19 +32,16 @@
 #include "libopera/opera_region.h"
 #include "libopera/opera_vdlp.h"
 
+#include "file/file_path.h"
+#include "retro_miscellaneous.h"
+#include "streams/file_stream.h"
+
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-const opera_bios_t *g_OPT_BIOS = NULL;
-const opera_bios_t *g_OPT_FONT = NULL;
-uint32_t g_OPT_VIDEO_WIDTH              = 0;
-uint32_t g_OPT_VIDEO_HEIGHT             = 0;
-uint32_t g_OPT_VIDEO_PITCH_SHIFT        = 0;
-uint32_t g_OPT_VDLP_FLAGS               = 0;
-uint32_t g_OPT_VDLP_PIXEL_FORMAT        = 0;
-uint32_t g_OPT_ACTIVE_DEVICES           = 0;
-uint32_t g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 0;
+opera_lr_opts_t g_OPTS = {0};
 
 static
 int
@@ -71,287 +70,549 @@ getval(const char *key_)
   return NULL;
 }
 
-bool
-opera_lr_opts_is_enabled(const char *key_)
+static
+int
+getval_as_int(const char *key_,
+              const int   default_)
 {
   const char *val;
 
   val = getval(key_);
   if(val == NULL)
-    return false;
-
-  return (strcmp(val,"enabled") == 0);
-}
-
-const
-opera_bios_t*
-opera_lr_opts_get_bios(void)
-{
-  const char *val;
-  const opera_bios_t *bios;
-
-  val = getval("bios");
-  if(val == NULL)
-    return NULL;
-
-  for(bios = opera_bios_begin(); bios != opera_bios_end(); bios++)
-    {
-      if(strcmp(bios->name,val))
-        continue;
-
-      return bios;
-    }
-
-  return NULL;
-}
-
-const
-opera_bios_t*
-opera_lr_opts_get_font(void)
-{
-  const char *val;
-  const opera_bios_t *font;
-
-  val = getval("font");
-  if(val == NULL)
-    return NULL;
-
-  for(font = opera_bios_font_begin(); font != opera_bios_font_end(); font++)
-    {
-      if(strcmp(font->name,val))
-        continue;
-
-      return font;
-    }
-
-  return NULL;
-}
-
-bool
-opera_lr_opts_is_nvram_shared(void)
-{
-  const char *val;
-
-  val = getval("nvram_storage");
-  if(val == NULL)
-    return true;
-
-  return (strcmp(val,"shared") == 0);
-}
-
-uint8_t
-opera_lr_opts_nvram_version(void)
-{
-  const char *val;
-
-  val = getval("nvram_version");
-  if(val == NULL)
-    return 0;
+    return default_;
 
   return atoi(val);
 }
 
-void
-opera_lr_opts_process_bios(void)
-{
-  g_OPT_BIOS = opera_lr_opts_get_bios();
-}
-
-void
-opera_lr_opts_process_font(void)
-{
-  g_OPT_FONT = opera_lr_opts_get_font();
-}
-
-void
-opera_lr_opts_process_region(void)
+static
+float
+getval_as_float(const char  *key_,
+                const float  default_)
 {
   const char *val;
+
+  val = getval(key_);
+  if(val == NULL)
+    return default_;
+
+  return atof(val);
+}
+
+static
+bool
+getval_is_str(const char *key_,
+              const char *str_,
+              const bool  default_)
+{
+  const char *val;
+
+  val = getval(key_);
+  if(val == NULL)
+    return default_;
+
+  return (strcmp(val,str_) == 0);
+}
+
+static
+bool
+getval_is_enabled(const char *key_,
+                  const bool  default_)
+{
+  return getval_is_str(key_,"enabled",default_);
+}
+
+static
+void
+opera_lr_opts_get_mem_cfg(opera_lr_opts_t *opts_)
+{
+  unsigned x;
+  const char *val;
+
+  opts_->mem_cfg = DRAM_VRAM_STOCK;
+
+  val = getval("mem_capacity");
+  if(val == NULL)
+    return;
+
+  x = 0;
+  sscanf(val,"%x",&x);
+
+  opts_->mem_cfg = (opera_mem_cfg_t)x;
+}
+
+static
+void
+opera_lr_opts_set_mem_cfg(opera_lr_opts_t const *opts_)
+{
+  if(g_OPTS.initialized_opera)
+    return;
+
+  opera_mem_init(opts_->mem_cfg);
+
+  g_OPTS.mem_cfg = opts_->mem_cfg;
+}
+
+static
+void
+opera_lr_opts_get_video_buffer(opera_lr_opts_t *opts_)
+{
+  (void)opts_;
+}
+
+static
+void
+opera_lr_opts_set_video_buffer(opera_lr_opts_t const *opts_)
+{
+  uint32_t size;
+
+  if(g_OPTS.initialized_opera)
+    return;
+  if(g_OPTS.video_buffer)
+    return;
+
+  /*
+   * The 4x multiplication is for hires mode
+   * 4 bytes per pixel will handle any format
+   * Wastes some memory but simplifies things
+   */
+  size = (opera_region_max_width() * opera_region_max_height() * 4);
+
+  g_OPTS.video_buffer = (uint32_t*)calloc(size,sizeof(uint32_t));
+
+  opera_vdlp_set_video_buffer(g_OPTS.video_buffer);
+}
+
+static
+int64_t
+read_file_from_system_directory(const char *filename_,
+                                uint8_t    *data_,
+                                int64_t     size_)
+{
+  int64_t rv;
+  RFILE *file;
+  const char *system_path;
+  char fullpath[PATH_MAX_LENGTH];
+
+  system_path = NULL;
+  rv = retro_environment_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY,&system_path);
+  if((rv == 0) || (system_path == NULL))
+    return -1;
+
+  fill_pathname_join(fullpath,system_path,filename_,PATH_MAX_LENGTH);
+
+  file = filestream_open(fullpath,RETRO_VFS_FILE_ACCESS_READ,RETRO_VFS_FILE_ACCESS_HINT_NONE);
+  if(file == NULL)
+    return -1;
+
+  rv = filestream_read(file,data_,size_);
+
+  filestream_close(file);
+
+  return rv;
+}
+
+static
+void
+opera_lr_opts_get_bios(opera_lr_opts_t *opts_)
+{
+  const char *val;
+  const opera_bios_t *bios;
+
+  opts_->bios = NULL;
+
+  val = getval("bios");
+  if(val == NULL)
+    return;
+
+  for(bios = opera_bios_begin(); bios != opera_bios_end(); bios++)
+    {
+      if(strcmp(bios->filename,val))
+        continue;
+
+      opts_->bios = bios;
+      return;
+    }
+}
+
+static
+void
+opera_lr_opts_set_bios(opera_lr_opts_t const *opts_)
+{
+  int64_t rv;
+
+  if(g_OPTS.initialized_opera)
+    return;
+
+  opera_lr_opts_set_mem_cfg(opts_);
+
+  if(opts_->bios == NULL)
+    {
+      retro_log_printf_cb(RETRO_LOG_ERROR,"[Opera]: no BIOS ROM found\n");
+      return;
+    }
+
+  rv = read_file_from_system_directory(opts_->bios->filename,ROM1,ROM1_SIZE);
+  if(rv < 0)
+    {
+      retro_log_printf_cb(RETRO_LOG_ERROR,
+                          "[Opera]: unable to find or load BIOS ROM - %s\n",
+                          opts_->bios->filename);
+      return;
+    }
+
+  retro_log_printf_cb(RETRO_LOG_INFO,
+                      "[Opera]: loaded BIOS ROM - %s\n",
+                      opts_->bios->filename);
+
+  opera_mem_rom1_byteswap32_if_le();
+
+  g_OPTS.bios = opts_->bios;
+}
+
+static
+void
+opera_lr_opts_get_font(opera_lr_opts_t *opts_)
+{
+  const char *val;
+  const opera_bios_t *font;
+
+  opts_->font = NULL;
+
+  val = getval("font");
+  if(val == NULL)
+    return;
+
+  for(font = opera_bios_font_begin(); font != opera_bios_font_end(); font++)
+    {
+      if(strcmp(font->filename,val))
+        continue;
+
+      opts_->font = font;
+      return;
+    }
+}
+
+static
+void
+opera_lr_opts_set_font(opera_lr_opts_t const *opts_)
+{
+  int64_t rv;
+
+  if(g_OPTS.initialized_opera)
+    return;
+
+  opera_lr_opts_set_mem_cfg(opts_);
+
+  if(opts_->font == NULL)
+    {
+      opera_mem_rom2_clear();
+      return;
+    }
+
+  rv = read_file_from_system_directory(opts_->font->filename,ROM2,ROM2_SIZE);
+  if(rv < 0)
+    {
+      retro_log_printf_cb(RETRO_LOG_ERROR,
+                          "[Opera]: unable to find or load FONT ROM - %s\n",
+                          opts_->font->filename);
+      return;
+    }
+
+  retro_log_printf_cb(RETRO_LOG_INFO,
+                      "[Opera]: loaded FONT ROM - %s\n",
+                      opts_->font->filename);
+
+  opera_mem_rom2_byteswap32_if_le();
+
+  g_OPTS.font = opts_->font;
+}
+
+static
+void
+opera_lr_opts_get_nvram_shared(opera_lr_opts_t *opts_)
+{
+  opts_->nvram_shared = getval_is_str("nvram_storage",
+                                      "shared",
+                                      true);
+}
+
+static
+void
+opera_lr_opts_set_nvram_shared(opera_lr_opts_t const *opts_)
+{
+  g_OPTS.nvram_shared = opts_->nvram_shared;
+}
+
+static
+void
+opera_lr_opts_get_nvram_version(opera_lr_opts_t *opts_)
+{
+  opts_->nvram_version = getval_as_int("nvram_version",0);
+}
+
+static
+void
+opera_lr_opts_set_nvram_version(opera_lr_opts_t const *opts_)
+{
+  g_OPTS.nvram_version = opts_->nvram_version;
+}
+
+static
+void
+opera_lr_opts_get_region(opera_lr_opts_t *opts_)
+{
+  const char *val;
+
+  opts_->region = OPERA_REGION_NTSC;
 
   val = getval("region");
   if(val == NULL)
     return;
 
   if(!strcmp(val,"ntsc"))
-    opera_region_set_NTSC();
+    opts_->region = OPERA_REGION_NTSC;
   else if(!strcmp(val,"pal1"))
-    opera_region_set_PAL1();
+    opts_->region = OPERA_REGION_PAL1;
   else if(!strcmp(val,"pal2"))
-    opera_region_set_PAL2();
+    opts_->region = OPERA_REGION_PAL2;
 }
 
+static
 void
-opera_lr_opts_process_cpu_overlock(void)
+opera_lr_opts_set_region(opera_lr_opts_t const *opts_)
 {
-  float mul;
-  const char *val;
+  switch(opts_->region)
+    {
+    default:
+    case OPERA_REGION_NTSC:
+      opera_region_set_NTSC();
+      break;
+    case OPERA_REGION_PAL1:
+      opera_region_set_PAL1();
+      break;
+    case OPERA_REGION_PAL2:
+      opera_region_set_PAL2();
+      break;
+    }
 
-  val = getval("cpu_overclock");
-  if(val == NULL)
-    return;
-
-  mul = atof(val);
-  opera_clock_cpu_set_freq_mul(mul);
+  g_OPTS.region       = opts_->region;
+  g_OPTS.video_width  = (opera_region_width()  << g_OPTS.high_resolution);
+  g_OPTS.video_height = (opera_region_height() << g_OPTS.high_resolution);
 }
 
-vdlp_pixel_format_e
-opera_lr_opts_get_vdlp_pixel_format(void)
+static
+void
+opera_lr_opts_get_cpu_overclock(opera_lr_opts_t *opts_)
+{
+  opts_->cpu_overclock = getval_as_float("cpu_overclock",1.0);
+}
+
+static
+void
+opera_lr_opts_set_cpu_overclock(opera_lr_opts_t const *opts_)
+{
+  opera_clock_cpu_set_freq_mul(opts_->cpu_overclock);
+  g_OPTS.cpu_overclock = opts_->cpu_overclock;
+}
+
+static
+void
+opera_lr_opts_get_vdlp_pixel_format(opera_lr_opts_t *opts_)
 {
   const char *val;
+
+  opts_->vdlp_pixel_format = VDLP_PIXEL_FORMAT_RGB565;
+  opts_->video_pitch_shift = 1;
 
   val = getval("vdlp_pixel_format");
   if(val == NULL)
-    return VDLP_PIXEL_FORMAT_XRGB8888;
+    return;
 
   if(!strcmp(val,"XRGB8888"))
-    return VDLP_PIXEL_FORMAT_XRGB8888;
+    {
+      opts_->vdlp_pixel_format = VDLP_PIXEL_FORMAT_XRGB8888;
+      opts_->video_pitch_shift = 2;
+    }
   else if(!strcmp(val,"RGB565"))
-    return VDLP_PIXEL_FORMAT_RGB565;
+    {
+      opts_->vdlp_pixel_format = VDLP_PIXEL_FORMAT_RGB565;
+      opts_->video_pitch_shift = 1;
+    }
   else if(!strcmp(val,"0RGB1555"))
-    return VDLP_PIXEL_FORMAT_0RGB1555;
-
-  return VDLP_PIXEL_FORMAT_XRGB8888;
+    {
+      opts_->vdlp_pixel_format = VDLP_PIXEL_FORMAT_0RGB1555;
+      opts_->video_pitch_shift = 1;
+    }
 }
 
-uint32_t
-opera_lr_opts_get_vdlp_flags(void)
+static
+void
+opera_lr_opts_set_vdlp_pixel_format(opera_lr_opts_t const *opts_)
 {
   uint32_t flags;
 
-  flags = VDLP_FLAG_NONE;
-  if(opera_lr_opts_is_enabled("high_resolution"))
-    flags |= VDLP_FLAG_HIRES_CEL;
-  if(opera_lr_opts_is_enabled("vdlp_bypass_clut"))
-    flags |= VDLP_FLAG_BYPASS_CLUT;
-
-  return flags;
-}
-
-void
-opera_lr_opts_process_vdlp_flags(void)
-{
-  g_OPT_VDLP_FLAGS = opera_lr_opts_get_vdlp_flags();
-}
-
-void
-opera_lr_opts_process_high_resolution(void)
-{
-  bool rv;
-
-  rv = opera_lr_opts_is_enabled("high_resolution");
-  if(rv)
-    {
-      HIRESMODE          = true;
-      g_OPT_VIDEO_WIDTH  = (opera_region_width()  << 1);
-      g_OPT_VIDEO_HEIGHT = (opera_region_height() << 1);
-    }
-  else
-    {
-      HIRESMODE          = false;
-      g_OPT_VIDEO_WIDTH  = opera_region_width();
-      g_OPT_VIDEO_HEIGHT = opera_region_height();
-    }
-}
-
-void
-opera_lr_opts_process_vdlp_pixel_format(void)
-{
-  static bool set = false;
-
-  if(set == true)
+  if(g_OPTS.initialized_libretro)
     return;
 
-  g_OPT_VDLP_PIXEL_FORMAT = opera_lr_opts_get_vdlp_pixel_format();
-  switch(g_OPT_VDLP_PIXEL_FORMAT)
-    {
-    default:
-    case VDLP_PIXEL_FORMAT_XRGB8888:
-      g_OPT_VIDEO_PITCH_SHIFT = 2;
-      break;
-    case VDLP_PIXEL_FORMAT_0RGB1555:
-    case VDLP_PIXEL_FORMAT_RGB565:
-      g_OPT_VIDEO_PITCH_SHIFT = 1;
-      break;
-    }
+  opera_vdlp_set_pixel_format(opts_->vdlp_pixel_format);
 
-  set = true;
+  g_OPTS.vdlp_pixel_format = opts_->vdlp_pixel_format;
+  g_OPTS.video_pitch_shift = opts_->video_pitch_shift;
 }
 
+static
 void
-opera_lr_opts_process_active_devices(void)
+opera_lr_opts_get_vdlp_bypass_clut(opera_lr_opts_t *opts_)
+{
+  opts_->vdlp_bypass_clut = getval_is_enabled("vdlp_bypass_clut",false);
+}
+
+static
+void
+opera_lr_opts_set_vdlp_bypass_clut(opera_lr_opts_t const *opts_)
+{
+  int rv;
+
+  rv = opera_vdlp_set_bypass_clut(opts_->vdlp_bypass_clut);
+  if(rv != 0)
+    return;
+
+  g_OPTS.vdlp_bypass_clut = opts_->vdlp_bypass_clut;
+}
+
+static
+void
+opera_lr_opts_get_high_resolution(opera_lr_opts_t *opts_)
+{
+  opts_->high_resolution = getval_is_enabled("high_resolution",false);
+}
+
+static
+void
+opera_lr_opts_set_high_resolution(opera_lr_opts_t const *opts_)
+{
+  opera_vdlp_set_hires(opts_->high_resolution);
+
+  g_OPTS.high_resolution = opts_->high_resolution;
+
+  HIRESMODE = g_OPTS.high_resolution;
+
+  g_OPTS.video_width  = (opera_region_width()  << g_OPTS.high_resolution);
+  g_OPTS.video_height = (opera_region_height() << g_OPTS.high_resolution);
+}
+
+static
+void
+opera_lr_opts_get_active_devices(opera_lr_opts_t *opts_)
+{
+  unsigned rv;
+
+  opts_->active_devices = getval_as_int("active_devices",1);
+  if(opts_->active_devices > LR_INPUT_MAX_DEVICES)
+    opts_->active_devices = 1;
+}
+
+static
+void
+opera_lr_opts_set_active_devices(opera_lr_opts_t const *opts_)
+{
+  g_OPTS.active_devices = opts_->active_devices;
+}
+
+static
+void
+opera_lr_opts_get_hide_lightgun_crosshairs(opera_lr_opts_t *opts_)
+{
+  opts_->hide_lightgun_crosshairs = getval_is_enabled("hide_lightgun_crosshairs",false);
+}
+
+static
+void
+opera_lr_opts_set_hide_lightgun_crosshairs(opera_lr_opts_t const *opts_)
+{
+  g_OPTS.hide_lightgun_crosshairs = opts_->hide_lightgun_crosshairs;
+}
+
+static
+void
+opera_lr_opts_get_madam_matrix_engine(opera_lr_opts_t *opts_)
 {
   const char *val;
 
-  g_OPT_ACTIVE_DEVICES = 1;
-
-  val = getval("active_devices");
-  if(val)
-    g_OPT_ACTIVE_DEVICES = atoi(val);
-
-  if(g_OPT_ACTIVE_DEVICES > LR_INPUT_MAX_DEVICES)
-    g_OPT_ACTIVE_DEVICES = 1;
-}
-
-void
-opera_lr_opts_process_hide_lightgun_crosshairs(void)
-{
-  bool rv;
-
-  rv = opera_lr_opts_is_enabled("hide_lightgun_crosshairs");
-
-  g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 0;
-
-  if(rv)
-    g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 1;
-  else
-    g_OPT_HIDE_LIGHTGUN_CROSSHAIRS = 0;
-}
-
-void
-opera_lr_opts_process_madam_matrix_engine(void)
-{
-  const char *val;
+  opts_->madam_matrix_engine = "hardware";
 
   val = getval("madam_matrix_engine");
   if(val == NULL)
     return;
 
-  if(strcmp(val,"software") == 0)
+  if(!strcmp(val,"software"))
+    opts_->madam_matrix_engine = "software";
+  else
+    opts_->madam_matrix_engine = "hardware";
+}
+
+static
+void
+opera_lr_opts_set_madam_matrix_engine(opera_lr_opts_t const *opts_)
+{
+  if(g_OPTS.initialized_opera)
+    return;
+
+  if(!strcmp(opts_->madam_matrix_engine,"software"))
     opera_madam_me_mode_software();
   else
     opera_madam_me_mode_hardware();
+
+  g_OPTS.madam_matrix_engine = opts_->madam_matrix_engine;
 }
 
+static
 void
-opera_lr_opts_process_debug(void)
+opera_lr_opts_get_kprint(opera_lr_opts_t *opts_)
 {
-  bool rv;
+  opts_->kprint = getval_is_enabled("kprint",false);
+}
 
-  rv = opera_lr_opts_is_enabled("kprint");
-  if(rv)
+static
+void
+opera_lr_opts_set_kprint(opera_lr_opts_t const *opts_)
+{
+  if(opts_->kprint)
     opera_madam_kprint_enable();
   else
     opera_madam_kprint_disable();
+
+  g_OPTS.kprint = opts_->kprint;
 }
 
+static
 void
-opera_lr_opts_process_dsp_threaded(void)
+opera_lr_opts_get_dsp_threaded(opera_lr_opts_t *opts_)
 {
-  bool rv;
-
-  rv = opera_lr_opts_is_enabled("dsp_threaded");
-
-  opera_lr_dsp_init(rv);
+  opts_->dsp_threaded = getval_is_enabled("dsp_threaded",false);
 }
 
+static
 void
-opera_lr_opts_process_swi_hle(void)
+opera_lr_opts_set_dsp_threaded(opera_lr_opts_t const *opts_)
 {
-  bool rv;
+  opera_lr_dsp_init(opts_->dsp_threaded);
+  g_OPTS.dsp_threaded = opts_->dsp_threaded;
+}
 
-  rv = getval("swi_hle");
+static
+void
+opera_lr_opts_get_swi_hle(opera_lr_opts_t *opts_)
+{
+  opts_->swi_hle = getval_is_enabled("swi_hle",false);
+}
 
-  opera_arm_swi_hle_set(rv);
+static
+void
+opera_lr_opts_set_swi_hle(opera_lr_opts_t const *opts_)
+{
+  opera_arm_swi_hle_set(opts_->swi_hle);
+  g_OPTS.swi_hle = opts_->swi_hle;
 }
 
 static
@@ -360,36 +621,122 @@ set_reset_bits(const char *key_,
                uint32_t    input_,
                uint32_t    bitmask_)
 {
-  return (opera_lr_opts_is_enabled(key_) ?
+  return (getval_is_enabled(key_,false) ?
           (input_ |  bitmask_) :
           (input_ & ~bitmask_));
 }
 
+static
 void
-opera_lr_opts_process_hacks(void)
+opera_lr_opts_get_hacks(opera_lr_opts_t *opts_)
 {
-  FIXMODE = set_reset_bits("hack_timing_1",FIXMODE,FIX_BIT_TIMING_1);
-  FIXMODE = set_reset_bits("hack_timing_3",FIXMODE,FIX_BIT_TIMING_3);
-  FIXMODE = set_reset_bits("hack_timing_5",FIXMODE,FIX_BIT_TIMING_5);
-  FIXMODE = set_reset_bits("hack_timing_6",FIXMODE,FIX_BIT_TIMING_6);
-  FIXMODE = set_reset_bits("hack_graphics_step_y",FIXMODE,FIX_BIT_GRAPHICS_STEP_Y);
+  uint32_t rv;
+
+  rv = 0;
+  rv = set_reset_bits("hack_timing_1",rv,FIX_BIT_TIMING_1);
+  rv = set_reset_bits("hack_timing_3",rv,FIX_BIT_TIMING_3);
+  rv = set_reset_bits("hack_timing_5",rv,FIX_BIT_TIMING_5);
+  rv = set_reset_bits("hack_timing_6",rv,FIX_BIT_TIMING_6);
+  rv = set_reset_bits("hack_graphics_step_y",rv,FIX_BIT_GRAPHICS_STEP_Y);
+
+  opts_->hack_flags = rv;
+}
+
+static
+void
+opera_lr_opts_set_hacks(opera_lr_opts_t const *opts_)
+{
+  FIXMODE           = opts_->hack_flags;
+  g_OPTS.hack_flags = opts_->hack_flags;
+}
+
+static
+void
+opera_lr_opts_get(opera_lr_opts_t *opts_)
+{
+  opera_lr_opts_get_mem_cfg(opts_);
+  opera_lr_opts_get_video_buffer(opts_);
+  opera_lr_opts_get_vdlp_pixel_format(opts_);
+  opera_lr_opts_get_bios(opts_);
+  opera_lr_opts_get_font(opts_);
+  opera_lr_opts_get_madam_matrix_engine(opts_);
+
+  opera_lr_opts_get_active_devices(opts_);
+  opera_lr_opts_get_cpu_overclock(opts_);
+  opera_lr_opts_get_dsp_threaded(opts_);
+  opera_lr_opts_get_hacks(opts_);
+  opera_lr_opts_get_hide_lightgun_crosshairs(opts_);
+  opera_lr_opts_get_high_resolution(opts_);
+  opera_lr_opts_get_kprint(opts_);
+  opera_lr_opts_get_nvram_shared(opts_);
+  opera_lr_opts_get_nvram_version(opts_);
+  opera_lr_opts_get_region(opts_);
+  opera_lr_opts_get_swi_hle(opts_);
+  opera_lr_opts_get_vdlp_bypass_clut(opts_);
+}
+
+static
+void
+opera_lr_opts_set(opera_lr_opts_t const *opts_)
+{
+  // Can only be set at start/restart
+  opera_lr_opts_set_mem_cfg(opts_);
+  opera_lr_opts_set_video_buffer(opts_);
+  opera_lr_opts_set_vdlp_pixel_format(opts_);
+  opera_lr_opts_set_bios(opts_);
+  opera_lr_opts_set_font(opts_);
+  opera_lr_opts_set_madam_matrix_engine(opts_);
+
+  // Can be updated at any time
+  opera_lr_opts_set_active_devices(opts_);
+  opera_lr_opts_set_cpu_overclock(opts_);
+  opera_lr_opts_set_dsp_threaded(opts_);
+  opera_lr_opts_set_hacks(opts_);
+  opera_lr_opts_set_hide_lightgun_crosshairs(opts_);
+  opera_lr_opts_set_high_resolution(opts_);
+  opera_lr_opts_set_kprint(opts_);
+  opera_lr_opts_set_nvram_shared(opts_);
+  opera_lr_opts_set_nvram_version(opts_);
+  opera_lr_opts_set_region(opts_);
+  opera_lr_opts_set_swi_hle(opts_);
+  opera_lr_opts_set_vdlp_bypass_clut(opts_);
+
+  g_OPTS.initialized_libretro = true;
+  g_OPTS.initialized_opera    = true;
 }
 
 void
-opera_lr_opts_process(void)
+opera_lr_opts_process()
 {
-  opera_lr_opts_process_bios();
-  opera_lr_opts_process_font();
-  opera_lr_opts_process_region();
-  opera_lr_opts_process_vdlp_pixel_format();
-  opera_lr_opts_process_high_resolution();
-  opera_lr_opts_process_vdlp_flags();
-  opera_lr_opts_process_cpu_overlock();
-  opera_lr_opts_process_dsp_threaded();
-  opera_lr_opts_process_active_devices();
-  opera_lr_opts_process_hide_lightgun_crosshairs();
-  opera_lr_opts_process_debug();
-  opera_lr_opts_process_madam_matrix_engine();
-  opera_lr_opts_process_swi_hle();
-  opera_lr_opts_process_hacks();
+  opera_lr_opts_t opts = {0};
+
+  opera_lr_opts_get(&opts);
+  opera_lr_opts_set(&opts);
+}
+
+void
+opera_lr_opts_reset()
+{
+  opera_lr_opts_t opts;
+
+  opts = g_OPTS;
+
+  if(g_OPTS.video_buffer)
+    free(g_OPTS.video_buffer);
+
+  opera_lr_dsp_destroy();
+
+  opera_mem_destroy();
+
+  memset(&g_OPTS,0,sizeof(g_OPTS));
+
+  g_OPTS.initialized_libretro = opts.initialized_libretro;
+  g_OPTS.vdlp_pixel_format    = opts.vdlp_pixel_format;
+  g_OPTS.video_pitch_shift    = opts.video_pitch_shift;
+}
+
+void
+opera_lr_opts_destroy()
+{
+  opera_lr_opts_reset();
 }

--- a/opera_lr_opts.h
+++ b/opera_lr_opts.h
@@ -2,41 +2,42 @@
 #define OPERA_LR_OPTS_H_INCLUDED
 
 #include "libopera/opera_bios.h"
+#include "libopera/opera_mem.h"
 #include "libopera/opera_vdlp.h"
+#include "libopera/opera_region.h"
 
-extern const opera_bios_t *g_OPT_BIOS;
-extern const opera_bios_t *g_OPT_FONT;
+typedef struct opera_lr_opts_t opera_lr_opts_t;
+struct opera_lr_opts_t
+{
+  bool initialized_libretro;
+  bool initialized_opera;
+  opera_bios_t const *bios;
+  opera_bios_t const *font;
+  bool nvram_shared;
+  uint8_t nvram_version;
+  opera_region_e region;
+  float cpu_overclock;
+  vdlp_pixel_format_e vdlp_pixel_format;
+  bool vdlp_bypass_clut;
+  uint32_t *video_buffer;
+  bool high_resolution;
+  unsigned video_width;
+  unsigned video_height;
+  unsigned video_pitch_shift;
+  unsigned active_devices;
+  opera_mem_cfg_t mem_cfg;
+  bool hide_lightgun_crosshairs;
+  char const *madam_matrix_engine;
+  bool kprint;
+  bool dsp_threaded;
+  bool swi_hle;
+  uint32_t hack_flags;
+};
 
-extern uint32_t g_OPT_VIDEO_WIDTH;
-extern uint32_t g_OPT_VIDEO_HEIGHT;
-extern uint32_t g_OPT_VIDEO_PITCH_SHIFT;
+extern opera_lr_opts_t g_OPTS;
 
-extern uint32_t g_OPT_VDLP_FLAGS;
-extern uint32_t g_OPT_VDLP_PIXEL_FORMAT;
-
-extern uint32_t g_OPT_ACTIVE_DEVICES;
-
-void                 opera_lr_opts_process(void);
-bool                 opera_lr_opts_is_enabled(const char *key);
-bool                 opera_lr_opts_is_nvram_shared(void);
-uint8_t              opera_lr_opts_nvram_version(void);
-const opera_bios_t  *opera_lr_opts_get_bios(void);
-const opera_bios_t  *opera_lr_opts_get_font(void);
-vdlp_pixel_format_e  opera_lr_opts_get_vdlp_pixel_format(void);
-uint32_t             opera_lr_opts_get_vdlp_flags(void);
-void                 opera_lr_opts_process_bios(void);
-void                 opera_lr_opts_process_font(void);
-void                 opera_lr_opts_process_cpu_overlock(void);
-void                 opera_lr_opts_process_region(void);
-void                 opera_lr_opts_process_vdlp_flags(void);
-void                 opera_lr_opts_process_high_resolution(void);
-void                 opera_lr_opts_process_vdlp_pixel_format(void);
-void                 opera_lr_opts_process_active_devices(void);
-void                 opera_lr_opts_process_hide_lightgun_crosshairs(void);
-void                 opera_lr_opts_process_madam_matrix_engine(void);
-void                 opera_lr_opts_process_debug(void);
-void                 opera_lr_opts_process_dsp_threaded(void);
-void                 opera_lr_opts_process_swi_hle(void);
-void                 opera_lr_opts_process_hacks(void);
+void opera_lr_opts_process();
+void opera_lr_opts_reset();
+void opera_lr_opts_destroy();
 
 #endif


### PR DESCRIPTION
This allows the system to have upto 16MB of combined DRAM and VRAM. This is really only useful for homebrew and it appears that not all retail software will work properly if configured with non-stock values.

This change also includes a reworking of the libretro variable handling, tweaks to some options and descriptions, as well as some changes to MADAM CEL rendering to accomidate for variable memory.