### PR TITLE
Fix for Idol Janshi Suchie-Pai Special. Black portrait ingame

### DIFF
--- a/libopera/opera_madam.c
+++ b/libopera/opera_madam.c
@@ -1257,7 +1257,9 @@ PDEC(const uint32_t  pixel_,
     pres=(pres|pdec.pmodeORmask)&pdec.pmodeANDmask;
   */
 
-  pproj.Transparent = (((pres & 0x7FFF) == 0x0) & pdec.tmask);
+  /* Gameblabla : This fixes black portrait issue in Idol sanshi. This needs careful handling or you may have no black outlines in Doom 3DO at menu. */
+  uint16_t transparentMask = (CCBFLAGS & CCB_NOBLK) ? 0x7fff : 0x7ffe;
+  pproj.Transparent = (((pres & transparentMask) == 0x0000) && pdec.tmask);
 
   return pres;
 }


### PR DESCRIPTION
Before

<img width="320" height="240" alt="broken" src="https://github.com/user-attachments/assets/5152e7c0-6777-4229-824a-0e9a1e11606e" />

After 

<img width="320" height="240" alt="idol" src="https://github.com/user-attachments/assets/08b7d1cd-683b-4c40-9e87-ab85cdd64b5f" />


This is also carefully done to avoid an issue with Doom 3DO PAL, otherwise no black outlines for text fonts. (see the issue below)

Fixes issue (this is a longstanding issue, i've seen some comments that may have suggested a fix above the lines in question but they were never acted upon) :
https://github.com/libretro/opera-libretro/issues/142

There may be a better way to fix this but i'm not aware of it. May need better regression testing as i've only tried 4 games so far.