### PR TITLE
Namespace FORCEINLINE and use local libretro headers

### DIFF
--- a/libopera/inline.h
+++ b/libopera/inline.h
@@ -17,16 +17,16 @@
 
 #endif /* INLINE */
 
-#ifndef FORCEINLINE
+#ifndef OPERA_FORCEINLINE
 
 #ifdef _MSC_VER
-#define FORCEINLINE __forceinline
+#define OPERA_FORCEINLINE __forceinline
 #elif defined(__GNUC__)
-#define FORCEINLINE __attribute__((always_inline)) INLINE
+#define OPERA_FORCEINLINE __attribute__((always_inline)) INLINE
 #else
-#define FORCEINLINE INLINE
+#define OPERA_FORCEINLINE INLINE
 #endif
 
-#endif /* FORCEINLINE */
+#endif /* OPERA_FORCEINLINE */
 
 #endif /* LIBOPERA_INLINE_H_INCLUDED */

--- a/libopera/opera_dsp.c
+++ b/libopera/opera_dsp.c
@@ -265,7 +265,7 @@ hash16(uint32_t i_,
 }
 
 static
-FORCEINLINE
+OPERA_FORCEINLINE
 int
 ADD_CFLAG(const uint32_t a_,
           const uint32_t b_,
@@ -277,7 +277,7 @@ ADD_CFLAG(const uint32_t a_,
 }
 
 static
-FORCEINLINE
+OPERA_FORCEINLINE
 int
 SUB_CFLAG(const uint32_t a_,
           const uint32_t b_,
@@ -289,7 +289,7 @@ SUB_CFLAG(const uint32_t a_,
 }
 
 static
-FORCEINLINE
+OPERA_FORCEINLINE
 int
 ADD_VFLAG(const uint32_t a_,
           const uint32_t b_,
@@ -300,7 +300,7 @@ ADD_VFLAG(const uint32_t a_,
 }
 
 static
-FORCEINLINE
+OPERA_FORCEINLINE
 int
 SUB_VFLAG(const uint32_t a_,
           const uint32_t b_,

--- a/libopera/opera_madam.c
+++ b/libopera/opera_madam.c
@@ -1488,7 +1488,7 @@ PPROJ_OUTPUT(uint32_t pproc_output_,
 #endif
 
 static
-FORCEINLINE
+OPERA_FORCEINLINE
 int8_t
 clamp_i8(const int8_t x_,
          const int8_t min_,
@@ -2467,7 +2467,7 @@ QuadCCWTest(int32_t wdt_)
 }
 
 static
-FORCEINLINE
+OPERA_FORCEINLINE
 int32_t
 ABS(const int32_t val_)
 {

--- a/opera_lr_dsp.h
+++ b/opera_lr_dsp.h
@@ -1,7 +1,7 @@
 #ifndef OPERA_LR_DSP_H_INCLUDED
 #define OPERA_LR_DSP_H_INCLUDED
 
-#include <stdbool.h>
+#include "boolean.h"
 
 void opera_lr_dsp_init(const bool threaded);
 void opera_lr_dsp_destroy(void);

--- a/retro_cdimage.h
+++ b/retro_cdimage.h
@@ -3,8 +3,9 @@
 
 #include "cuefile.h"
 
-#include <boolean.h>
-#include <streams/interface_stream.h>
+#include "boolean.h"
+#include "streams/interface_stream.h"
+
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION
- Rename FORCEINLINE to OPERA_FORCEINLINE across DSP and MADAM helpers to avoid macro conflicts.
- Include local boolean and stream headers from libretro-facing headers.