### PR TITLE
DSPP: return CPU-supplied DSP FIFO values

### DIFF
--- a/libopera/opera_dsp.c
+++ b/libopera/opera_dsp.c
@@ -350,7 +350,7 @@ dsp_read(uint32_t addr_)
         val=IMem[addr-0x80];
       */
       if(DSP.CPUSupply[addr_ - 0xF0])
-        return (DSP.CPUSupply[addr_ - 0xF0] = 0, prng16());
+        return (DSP.CPUSupply[addr_ - 0xF0] = 0, DSP.IMem[addr_ - 0x80]);
       return opera_clio_fifo_ei(addr_ & 0x0F);
     case 0x70:
     case 0x71:


### PR DESCRIPTION
CPU writes to EI FIFO-head addresses 0x70..0x7c set CPUSupply and latch the supplied word in EIRAM. When the DSP later reads the normal input FIFO window at 0xf0..0xfc, consume that latched word instead of returning PRNG data.

The random source is the separate DSPP noise register. Using it for a valid CPU-supplied FIFO read injects spurious samples, causing startup pops in Flashback sound effects such as footsteps.

Source:
- WO 94/16383, PDF pp.17-18: 0EAh is the pseudorandom noise generator, 0F0h through 0FCh are input FIFOs, and 070h through 07Eh read the corresponding input FIFOs without removing the input word.
- WO 94/16383, PDF pp.25-26: EI FIFO reads refill EIRAM from the corresponding FIFO, and the EI FIFO control unit also receives direct host CPU input.
- Portfolio OS src/audio/audiofolio/dspp_addresses.h: DSPP_FIFOHEAD_ZERO_ADDRESS is 0x0070 and DSPI_NOISE is 0x00EA, separating FIFO-head data from the noise register.
- Portfolio OS src/audio/audiofolio/dspp_touch_anvil.c: dsphResetFIFO() clears DSPP_FIFOHEAD_ZERO_ADDRESS + DMAChan in EI memory to reduce pops.