### PR TITLE
MADAM: include arbitrary CEL span endpoint

### DIFF
--- a/libopera/opera_madam.c
+++ b/libopera/opera_madam.c
@@ -3215,7 +3215,7 @@ TexelDrawArbitrary(uint16_t CURPIX_,
                   if(x < 0)
                     x = 0;
 
-                  maxx = xpoints[3];
+                  maxx = xpoints[3] + 1;
                   if(maxx > maxxt)
                     maxx = maxxt;
 
@@ -3240,7 +3240,7 @@ TexelDrawArbitrary(uint16_t CURPIX_,
               if(x < 0)
                 x = 0;
 
-              maxx = xpoints[1];
+              maxx = xpoints[1] + 1;
               if(maxx > maxxt)
                 maxx = maxxt;
 


### PR DESCRIPTION
Arbitrary CEL rendering treated computed horizontal span endpoints as exclusive. When adjacent skybox CELs met on integer x boundaries, neither CEL covered the shared column, leaving the SPORT clear color in the frame buffer and producing vertical seams in NFS.

Include the right endpoint before clipping arbitrary CEL spans so shared boundaries are overwritten by CEL pixels instead of preserving stale clear-color columns.