### PR TITLE
Add terminal mode and artifact capture options

### DIFF
--- a/.agents/skills/opera-test-harness/SKILL.md
+++ b/.agents/skills/opera-test-harness/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: opera-test-harness
+description: Use when running, automating, or debugging the 3DO libretro "opera" core with the test-harness binary, including terminal mode, controls, BIOS/core defaults, screenshots, ROMs, scripted input, and benchmarks.
+---
+
+# opera-test-harness
+
+A headless runner for the `opera_libretro.so` 3DO core. It loads a
+libretro core + 3DO BIOS + (optional) disc image, runs frames with no
+display/audio hardware needed, and emits screenshots, audio, and
+structured metrics for CI or regression use.
+
+## When to use this skill
+
+Trigger when:
+
+- User asks to "run the core", "test the core", "boot a 3DO disc",
+  "capture a screenshot" of a 3DO game, or "benchmark" the core.
+- User mentions `test-harness`, `test_harness.c`, "test harness" or
+  headless core testing.
+- User asks to script button presses or compare runs against a
+  baseline.
+
+## Build
+
+From the repo root:
+
+```sh
+make harness    # builds ./test-harness
+```
+
+`test-harness` depends on `tools/stb_image_write.h` and links `-ldl
+-lm`.
+
+## BIOS
+
+If `--core` is omitted, the harness looks for `opera_libretro.so`
+beside the `test-harness` executable. If `--bios` is omitted, it
+prefers `panafz1.bin` beside `test-harness`, then falls back to
+filename search.
+
+`--bios` accepts either a real path or a bare filename listed in
+`BIOS_ROMS[]` (`tools/test_harness.c`). Bare filenames are searched
+beside `test-harness`, then in RetroArch system dirs
+(`RETROARCH_ROM_DIRS[]`). Use `--list-bios` to print recognized BIOS
+ROMs and any resolved local paths.
+
+## Canonical invocation
+
+```sh
+./test-harness \
+  --core ./opera_libretro.so \
+  --bios /path/to/panafz1.bin \
+  --title "/path/to/Game (USA).bin" \
+  --frames 600 \
+  --screenshot-at 120=/tmp/early.png \
+  --screenshot-at 300=/tmp/title.png \
+  --screenshot /tmp/final.png \
+  --wall-timeout 30 \
+  --output-dir /tmp/run
+```
+
+`--core` and `--bios` are optional when the defaults are available
+beside `test-harness` or in the configured BIOS search
+paths. Everything else is optional.
+
+## Key flags
+
+### Duration
+- `--frames N` — exact frame count.
+- `--seconds S` — `ceil(S * core_fps)` frames (60 fps for NTSC).
+- `--wall-timeout S` — abort if the run wallclock exceeds S seconds;
+ watchdog against a hung core. **Always set this** for CI/automated
+ runs.
+
+### Capturing frames
+- `--screenshot PATH` — final frame as PNG.
+- `--screenshot-at N=PATH` (repeatable) — specific frame N as PNG.
+- `--screenshot-every N=DIR` — every Nth frame as
+ `DIR/frameNNNNNN.png`.  Useful for contact-sheet previews and
+ boot-animation capture.
+- `--screenshot-when MODE` — filter `--screenshot-every` output:
+  `NONBLANK` skips all-black frames; `CHANGED` skips frames identical
+  to the previous one written. Reduces contact-sheet noise from
+  frozen/loading screens.
+
+### Input
+- `--input SPEC` (repeatable) — `WHEN=BUTTON`, optionally
+ `WHEN+DURATION=BUTTON`.
+- `--input-file PATH` — text file with one `SPEC` per line; blank
+ lines and `#`-prefixed comments are skipped.
+
+Spec syntax:
+- `WHEN` = `NF` (N frames) or `NS` (N seconds, converted via core
+  fps).
+- `DURATION` = same units; defaults to 1 frame if omitted.
+- `BUTTON` ∈ `A B C X P L R UP DOWN LEFT RIGHT` (case-insensitive).
+
+Examples:
+- `120F=A` — press A on frame 120 only.
+- `2S=X` — press X at 2 s for 1 frame.
+- `2S+0.5S=A` — press A at 2 s, hold for half a second.
+- `120F+30F=P` — press P at frame 120, hold for 30 frames.
+
+### Audio & artifacts
+- `--audio PATH` — stereo s16le WAV of the whole run.
+- `--log PATH` — per-run log (default `<output-dir>/run.log`).
+- `--metrics PATH` — JSON with frame counts, fps, timings, input
+ events, screenshot tallies, etc. (default
+ `<output-dir>/metrics.json`).
+
+### Core options
+- `--option KEY=VALUE` (repeatable) — override core options, e.g.
+ `--option opera_region=ntsc`, `--option
+ opera_high_resolution=enabled`.  Keys are normalized
+ (case-insensitive, `_`/`-` interchange).
+
+### Terminal mode
+- `--terminal` — opt-in live terminal framebuffer and keyboard
+  controls.
+- `--terminal-fps N` — cap terminal redraw rate; `0` redraws every
+  video frame.  Default is adaptive up to 30 FPS.
+- `--terminal-render auto|half|ascii` — override render mode. Default
+  is capability-detected.
+- `--terminal-color auto|true|256|mono` — override color mode. Default
+  is capability-detected.
+- `--terminal-button-hold N` — keep terminal button presses active for
+  N frames after a key byte is received. Default is 6.
+
+Terminal controls:
+- `W/A/S/D` = Up/Left/Down/Right.
+- Arrow keys are secondary movement aliases.
+- `J` = 3DO A.
+- `K` = 3DO B.
+- `L` = 3DO C.
+- `'` = 3DO X/Stop.
+- `U` = Left Trigger.
+- `I` = Right Trigger.
+- `Enter` = Play.
+- `Esc Esc` = quit terminal mode.
+- `Ctrl-C` also requests quit/cleanup.
+
+Terminal implementation notes:
+- Terminal mode opens `/dev/tty`, uses raw mode, alternate screen, and
+  cursor hide/show sequences.
+- Rendering uses half-block Unicode `▀` when supported and ASCII
+  fallback when needed.
+- The renderer uses cached source-coordinate maps, row hashes, row
+  diffing, changed-span emission, batched writes, and run-length glyph
+  output.
+- `SIGWINCH` marks terminal size dirty; size is refreshed on
+  open/resize rather than every rendered frame.
+- Termination signals exit through normal cleanup so raw mode and
+  alt-screen are restored.
+
+## Exit codes / status
+
+- `0` — `ok`: ran cleanly.
+- `1` — `error` / `artifact_error` / `metrics_error`: core failed to
+ run, a screenshot/audio/metrics write failed, or required args
+ missing.
+- `124` — `timeout`: `--wall-timeout` fired.
+- `128+signal` — terminated by a handled process signal after cleanup.
+
+The terse stderr line is `test-harness: <status>, frames=N, log=...,
+metrics=...`.  Full detail lives in `metrics.json` under `status`,
+`exit_code`, `frames_run`, `average_fps`, `speed_multiplier`,
+`input_events[]`, `log_counts`, etc.
+
+## Common workflows
+
+### Boot-to-title screenshot
+```sh
+./test-harness --core ./opera_libretro.so --bios panafz1.bin \
+  --title "/path/to/Game.cue" --seconds 10 \
+  --screenshot /tmp/title.png --wall-timeout 30
+```
+
+### Scripted playthrough
+Write a `inputs.txt` with one event per line and comments:
+```
+#dismiss BIOS + publisher logos
+20S=A
+22S=A
+24S=A
+#enter main menu, start game
+30S=A
+30S+2S=X        # hold X through the load screen
+```
+Then:
+```sh
+./test-harness --core ... --bios ... --title ... \
+  --frames 2400 --input-file inputs.txt \
+  --screenshot-every 300=/tmp/frames --wall-timeout 60
+```
+
+### Multiple capture points plus contact sheet
+```sh
+./test-harness --core ... --bios ... --title ... \
+  --frames 600 \
+  --screenshot-at 60=/tmp/01.png \
+  --screenshot-at 600=/tmp/end.png \
+  --screenshot-every 120=/tmp/grid
+```
+
+### Regression / benchmarking
+Pin a stable frame window so rebuilds can be compared apples-to-apples:
+```sh
+./test-harness --core ... --bios ... --title ... \
+  --frames 1800 \
+  --benchmark-start-frame 600 --benchmark-end-frame 1800 \
+  --cpu 2 --wall-timeout 120 \
+  --metrics /tmp/metrics.json
+```
+`metrics.json` `benchmark_average_fps` and `benchmark_speed_multiplier` are
+the stable comparison numbers.
+
+## Gotchas
+
+- **`--core` and `--bios` are required.** `--bios` may be a bare
+  filename only
+- **`--core` and `--bios` have executable-directory defaults.** If the
+  defaults are not available, pass explicit paths or put recognized
+  BIOS filenames in a searched RetroArch system directory.
+- **`--wall-timeout` counts cumulative wall seconds, not per-frame.**
+ For hung-core detection in CI set it generously above expected wall
+ time.
+- **Screenshots are written via `stb_image_write`** (PNG, no external
+ deps).  `--screenshot-at` captures are buffered in RAM until
+ end-of-run; `--screenshot-every` PNGs are written immediately, so
+ memory stays flat even for very long runs.
+- **`--screenshot-when` compares pixels (not padding).** It packs each
+ frame by `width * pixel_size` before comparing, so stride/padding
+ differences don't cause false "changed" results. `CHANGED` keeps a
+ packed copy of the last written frame in memory (~width*height*4
+ bytes max).
+- **Input ports.** Input events target controller port 0 (joypad)
+ only. Multi- port play is not yet supported.
+- **Frame numbering is 1-based.** `--screenshot-at 1` captures the
+  first frame.
+- **GPU threads are pinned with `--cpu`,** which also sets affinity
+ for any threads the core spawns.
+- **Run artifacts go under `--output-dir`** (default
+ `./test-harness-runs/<YYYYMMDD-HHMMSS-pid>/`); the temp `work/`
+ subdir (system + save) is removed unless `--keep-work-dir` or
+ `--work-dir` is set.

--- a/Makefile
+++ b/Makefile
@@ -645,11 +645,11 @@ endif
 
 HARNESS_TARGET := test-harness
 HARNESS_CFLAGS := -O2 -g -Wall -Wextra $(INCFLAGS)
-HARNESS_LIBS := -ldl
+HARNESS_LIBS := -ldl -lm
 
 harness: $(HARNESS_TARGET)
 
-$(HARNESS_TARGET): tools/test_harness.c
+$(HARNESS_TARGET): tools/test_harness.c tools/stb_image_write.h
 	$(CC) -o $@ $< $(HARNESS_CFLAGS) $(HARNESS_LIBS)
 
 clean:

--- a/tools/stb_image_write.h
+++ b/tools/stb_image_write.h
@@ -1,0 +1,1724 @@
+/* stb_image_write - v1.16 - public domain - http://nothings.org/stb
+   writes out PNG/BMP/TGA/JPEG/HDR images to C stdio - Sean Barrett 2010-2015
+                                     no warranty implied; use at your own risk
+
+   Before #including,
+
+       #define STB_IMAGE_WRITE_IMPLEMENTATION
+
+   in the file that you want to have the implementation.
+
+   Will probably not work correctly with strict-aliasing optimizations.
+
+ABOUT:
+
+   This header file is a library for writing images to C stdio or a callback.
+
+   The PNG output is not optimal; it is 20-50% larger than the file
+   written by a decent optimizing implementation; though providing a custom
+   zlib compress function (see STBIW_ZLIB_COMPRESS) can mitigate that.
+   This library is designed for source code compactness and simplicity,
+   not optimal image file size or run-time performance.
+
+BUILDING:
+
+   You can #define STBIW_ASSERT(x) before the #include to avoid using assert.h.
+   You can #define STBIW_MALLOC(), STBIW_REALLOC(), and STBIW_FREE() to replace
+   malloc,realloc,free.
+   You can #define STBIW_MEMMOVE() to replace memmove()
+   You can #define STBIW_ZLIB_COMPRESS to use a custom zlib-style compress function
+   for PNG compression (instead of the builtin one), it must have the following signature:
+   unsigned char * my_compress(unsigned char *data, int data_len, int *out_len, int quality);
+   The returned data will be freed with STBIW_FREE() (free() by default),
+   so it must be heap allocated with STBIW_MALLOC() (malloc() by default),
+
+UNICODE:
+
+   If compiling for Windows and you wish to use Unicode filenames, compile
+   with
+       #define STBIW_WINDOWS_UTF8
+   and pass utf8-encoded filenames. Call stbiw_convert_wchar_to_utf8 to convert
+   Windows wchar_t filenames to utf8.
+
+USAGE:
+
+   There are five functions, one for each image file format:
+
+     int stbi_write_png(char const *filename, int w, int h, int comp, const void *data, int stride_in_bytes);
+     int stbi_write_bmp(char const *filename, int w, int h, int comp, const void *data);
+     int stbi_write_tga(char const *filename, int w, int h, int comp, const void *data);
+     int stbi_write_jpg(char const *filename, int w, int h, int comp, const void *data, int quality);
+     int stbi_write_hdr(char const *filename, int w, int h, int comp, const float *data);
+
+     void stbi_flip_vertically_on_write(int flag); // flag is non-zero to flip data vertically
+
+   There are also five equivalent functions that use an arbitrary write function. You are
+   expected to open/close your file-equivalent before and after calling these:
+
+     int stbi_write_png_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data, int stride_in_bytes);
+     int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
+     int stbi_write_tga_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
+     int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const float *data);
+     int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int quality);
+
+   where the callback is:
+      void stbi_write_func(void *context, void *data, int size);
+
+   You can configure it with these global variables:
+      int stbi_write_tga_with_rle;             // defaults to true; set to 0 to disable RLE
+      int stbi_write_png_compression_level;    // defaults to 8; set to higher for more compression
+      int stbi_write_force_png_filter;         // defaults to -1; set to 0..5 to force a filter mode
+
+
+   You can define STBI_WRITE_NO_STDIO to disable the file variant of these
+   functions, so the library will not use stdio.h at all. However, this will
+   also disable HDR writing, because it requires stdio for formatted output.
+
+   Each function returns 0 on failure and non-0 on success.
+
+   The functions create an image file defined by the parameters. The image
+   is a rectangle of pixels stored from left-to-right, top-to-bottom.
+   Each pixel contains 'comp' channels of data stored interleaved with 8-bits
+   per channel, in the following order: 1=Y, 2=YA, 3=RGB, 4=RGBA. (Y is
+   monochrome color.) The rectangle is 'w' pixels wide and 'h' pixels tall.
+   The *data pointer points to the first byte of the top-left-most pixel.
+   For PNG, "stride_in_bytes" is the distance in bytes from the first byte of
+   a row of pixels to the first byte of the next row of pixels.
+
+   PNG creates output files with the same number of components as the input.
+   The BMP format expands Y to RGB in the file format and does not
+   output alpha.
+
+   PNG supports writing rectangles of data even when the bytes storing rows of
+   data are not consecutive in memory (e.g. sub-rectangles of a larger image),
+   by supplying the stride between the beginning of adjacent rows. The other
+   formats do not. (Thus you cannot write a native-format BMP through the BMP
+   writer, both because it is in BGR order and because it may have padding
+   at the end of the line.)
+
+   PNG allows you to set the deflate compression level by setting the global
+   variable 'stbi_write_png_compression_level' (it defaults to 8).
+
+   HDR expects linear float data. Since the format is always 32-bit rgb(e)
+   data, alpha (if provided) is discarded, and for monochrome data it is
+   replicated across all three channels.
+
+   TGA supports RLE or non-RLE compressed data. To use non-RLE-compressed
+   data, set the global variable 'stbi_write_tga_with_rle' to 0.
+
+   JPEG does ignore alpha channels in input data; quality is between 1 and 100.
+   Higher quality looks better but results in a bigger image.
+   JPEG baseline (no JPEG progressive).
+
+CREDITS:
+
+
+   Sean Barrett           -    PNG/BMP/TGA
+   Baldur Karlsson        -    HDR
+   Jean-Sebastien Guay    -    TGA monochrome
+   Tim Kelsey             -    misc enhancements
+   Alan Hickman           -    TGA RLE
+   Emmanuel Julien        -    initial file IO callback implementation
+   Jon Olick              -    original jo_jpeg.cpp code
+   Daniel Gibson          -    integrate JPEG, allow external zlib
+   Aarni Koskela          -    allow choosing PNG filter
+
+   bugfixes:
+      github:Chribba
+      Guillaume Chereau
+      github:jry2
+      github:romigrou
+      Sergio Gonzalez
+      Jonas Karlsson
+      Filip Wasil
+      Thatcher Ulrich
+      github:poppolopoppo
+      Patrick Boettcher
+      github:xeekworx
+      Cap Petschulat
+      Simon Rodriguez
+      Ivan Tikhonov
+      github:ignotion
+      Adam Schackart
+      Andrew Kensler
+
+LICENSE
+
+  See end of file for license information.
+
+*/
+
+#ifndef INCLUDE_STB_IMAGE_WRITE_H
+#define INCLUDE_STB_IMAGE_WRITE_H
+
+#include <stdlib.h>
+
+// if STB_IMAGE_WRITE_STATIC causes problems, try defining STBIWDEF to 'inline' or 'static inline'
+#ifndef STBIWDEF
+#ifdef STB_IMAGE_WRITE_STATIC
+#define STBIWDEF  static
+#else
+#ifdef __cplusplus
+#define STBIWDEF  extern "C"
+#else
+#define STBIWDEF  extern
+#endif
+#endif
+#endif
+
+#ifndef STB_IMAGE_WRITE_STATIC  // C++ forbids static forward declarations
+STBIWDEF int stbi_write_tga_with_rle;
+STBIWDEF int stbi_write_png_compression_level;
+STBIWDEF int stbi_write_force_png_filter;
+#endif
+
+#ifndef STBI_WRITE_NO_STDIO
+STBIWDEF int stbi_write_png(char const *filename, int w, int h, int comp, const void  *data, int stride_in_bytes);
+STBIWDEF int stbi_write_bmp(char const *filename, int w, int h, int comp, const void  *data);
+STBIWDEF int stbi_write_tga(char const *filename, int w, int h, int comp, const void  *data);
+STBIWDEF int stbi_write_hdr(char const *filename, int w, int h, int comp, const float *data);
+STBIWDEF int stbi_write_jpg(char const *filename, int x, int y, int comp, const void  *data, int quality);
+
+#ifdef STBIW_WINDOWS_UTF8
+STBIWDEF int stbiw_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input);
+#endif
+#endif
+
+typedef void stbi_write_func(void *context, void *data, int size);
+
+STBIWDEF int stbi_write_png_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data, int stride_in_bytes);
+STBIWDEF int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
+STBIWDEF int stbi_write_tga_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
+STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const float *data);
+STBIWDEF int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void  *data, int quality);
+
+STBIWDEF void stbi_flip_vertically_on_write(int flip_boolean);
+
+#endif//INCLUDE_STB_IMAGE_WRITE_H
+
+#ifdef STB_IMAGE_WRITE_IMPLEMENTATION
+
+#ifdef _WIN32
+   #ifndef _CRT_SECURE_NO_WARNINGS
+   #define _CRT_SECURE_NO_WARNINGS
+   #endif
+   #ifndef _CRT_NONSTDC_NO_DEPRECATE
+   #define _CRT_NONSTDC_NO_DEPRECATE
+   #endif
+#endif
+
+#ifndef STBI_WRITE_NO_STDIO
+#include <stdio.h>
+#endif // STBI_WRITE_NO_STDIO
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#if defined(STBIW_MALLOC) && defined(STBIW_FREE) && (defined(STBIW_REALLOC) || defined(STBIW_REALLOC_SIZED))
+// ok
+#elif !defined(STBIW_MALLOC) && !defined(STBIW_FREE) && !defined(STBIW_REALLOC) && !defined(STBIW_REALLOC_SIZED)
+// ok
+#else
+#error "Must define all or none of STBIW_MALLOC, STBIW_FREE, and STBIW_REALLOC (or STBIW_REALLOC_SIZED)."
+#endif
+
+#ifndef STBIW_MALLOC
+#define STBIW_MALLOC(sz)        malloc(sz)
+#define STBIW_REALLOC(p,newsz)  realloc(p,newsz)
+#define STBIW_FREE(p)           free(p)
+#endif
+
+#ifndef STBIW_REALLOC_SIZED
+#define STBIW_REALLOC_SIZED(p,oldsz,newsz) STBIW_REALLOC(p,newsz)
+#endif
+
+
+#ifndef STBIW_MEMMOVE
+#define STBIW_MEMMOVE(a,b,sz) memmove(a,b,sz)
+#endif
+
+
+#ifndef STBIW_ASSERT
+#include <assert.h>
+#define STBIW_ASSERT(x) assert(x)
+#endif
+
+#define STBIW_UCHAR(x) (unsigned char) ((x) & 0xff)
+
+#ifdef STB_IMAGE_WRITE_STATIC
+static int stbi_write_png_compression_level = 8;
+static int stbi_write_tga_with_rle = 1;
+static int stbi_write_force_png_filter = -1;
+#else
+int stbi_write_png_compression_level = 8;
+int stbi_write_tga_with_rle = 1;
+int stbi_write_force_png_filter = -1;
+#endif
+
+static int stbi__flip_vertically_on_write = 0;
+
+STBIWDEF void stbi_flip_vertically_on_write(int flag)
+{
+   stbi__flip_vertically_on_write = flag;
+}
+
+typedef struct
+{
+   stbi_write_func *func;
+   void *context;
+   unsigned char buffer[64];
+   int buf_used;
+} stbi__write_context;
+
+// initialize a callback-based context
+static void stbi__start_write_callbacks(stbi__write_context *s, stbi_write_func *c, void *context)
+{
+   s->func    = c;
+   s->context = context;
+}
+
+#ifndef STBI_WRITE_NO_STDIO
+
+static void stbi__stdio_write(void *context, void *data, int size)
+{
+   fwrite(data,1,size,(FILE*) context);
+}
+
+#if defined(_WIN32) && defined(STBIW_WINDOWS_UTF8)
+#ifdef __cplusplus
+#define STBIW_EXTERN extern "C"
+#else
+#define STBIW_EXTERN extern
+#endif
+STBIW_EXTERN __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int cp, unsigned long flags, const char *str, int cbmb, wchar_t *widestr, int cchwide);
+STBIW_EXTERN __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, const wchar_t *widestr, int cchwide, char *str, int cbmb, const char *defchar, int *used_default);
+
+STBIWDEF int stbiw_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input)
+{
+   return WideCharToMultiByte(65001 /* UTF8 */, 0, input, -1, buffer, (int) bufferlen, NULL, NULL);
+}
+#endif
+
+static FILE *stbiw__fopen(char const *filename, char const *mode)
+{
+   FILE *f;
+#if defined(_WIN32) && defined(STBIW_WINDOWS_UTF8)
+   wchar_t wMode[64];
+   wchar_t wFilename[1024];
+   if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, filename, -1, wFilename, sizeof(wFilename)/sizeof(*wFilename)))
+      return 0;
+
+   if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, mode, -1, wMode, sizeof(wMode)/sizeof(*wMode)))
+      return 0;
+
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != _wfopen_s(&f, wFilename, wMode))
+      f = 0;
+#else
+   f = _wfopen(wFilename, wMode);
+#endif
+
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != fopen_s(&f, filename, mode))
+      f=0;
+#else
+   f = fopen(filename, mode);
+#endif
+   return f;
+}
+
+static int stbi__start_write_file(stbi__write_context *s, const char *filename)
+{
+   FILE *f = stbiw__fopen(filename, "wb");
+   stbi__start_write_callbacks(s, stbi__stdio_write, (void *) f);
+   return f != NULL;
+}
+
+static void stbi__end_write_file(stbi__write_context *s)
+{
+   fclose((FILE *)s->context);
+}
+
+#endif // !STBI_WRITE_NO_STDIO
+
+typedef unsigned int stbiw_uint32;
+typedef int stb_image_write_test[sizeof(stbiw_uint32)==4 ? 1 : -1];
+
+static void stbiw__writefv(stbi__write_context *s, const char *fmt, va_list v)
+{
+   while (*fmt) {
+      switch (*fmt++) {
+         case ' ': break;
+         case '1': { unsigned char x = STBIW_UCHAR(va_arg(v, int));
+                     s->func(s->context,&x,1);
+                     break; }
+         case '2': { int x = va_arg(v,int);
+                     unsigned char b[2];
+                     b[0] = STBIW_UCHAR(x);
+                     b[1] = STBIW_UCHAR(x>>8);
+                     s->func(s->context,b,2);
+                     break; }
+         case '4': { stbiw_uint32 x = va_arg(v,int);
+                     unsigned char b[4];
+                     b[0]=STBIW_UCHAR(x);
+                     b[1]=STBIW_UCHAR(x>>8);
+                     b[2]=STBIW_UCHAR(x>>16);
+                     b[3]=STBIW_UCHAR(x>>24);
+                     s->func(s->context,b,4);
+                     break; }
+         default:
+            STBIW_ASSERT(0);
+            return;
+      }
+   }
+}
+
+static void stbiw__writef(stbi__write_context *s, const char *fmt, ...)
+{
+   va_list v;
+   va_start(v, fmt);
+   stbiw__writefv(s, fmt, v);
+   va_end(v);
+}
+
+static void stbiw__write_flush(stbi__write_context *s)
+{
+   if (s->buf_used) {
+      s->func(s->context, &s->buffer, s->buf_used);
+      s->buf_used = 0;
+   }
+}
+
+static void stbiw__putc(stbi__write_context *s, unsigned char c)
+{
+   s->func(s->context, &c, 1);
+}
+
+static void stbiw__write1(stbi__write_context *s, unsigned char a)
+{
+   if ((size_t)s->buf_used + 1 > sizeof(s->buffer))
+      stbiw__write_flush(s);
+   s->buffer[s->buf_used++] = a;
+}
+
+static void stbiw__write3(stbi__write_context *s, unsigned char a, unsigned char b, unsigned char c)
+{
+   int n;
+   if ((size_t)s->buf_used + 3 > sizeof(s->buffer))
+      stbiw__write_flush(s);
+   n = s->buf_used;
+   s->buf_used = n+3;
+   s->buffer[n+0] = a;
+   s->buffer[n+1] = b;
+   s->buffer[n+2] = c;
+}
+
+static void stbiw__write_pixel(stbi__write_context *s, int rgb_dir, int comp, int write_alpha, int expand_mono, unsigned char *d)
+{
+   unsigned char bg[3] = { 255, 0, 255}, px[3];
+   int k;
+
+   if (write_alpha < 0)
+      stbiw__write1(s, d[comp - 1]);
+
+   switch (comp) {
+      case 2: // 2 pixels = mono + alpha, alpha is written separately, so same as 1-channel case
+      case 1:
+         if (expand_mono)
+            stbiw__write3(s, d[0], d[0], d[0]); // monochrome bmp
+         else
+            stbiw__write1(s, d[0]);  // monochrome TGA
+         break;
+      case 4:
+         if (!write_alpha) {
+            // composite against pink background
+            for (k = 0; k < 3; ++k)
+               px[k] = bg[k] + ((d[k] - bg[k]) * d[3]) / 255;
+            stbiw__write3(s, px[1 - rgb_dir], px[1], px[1 + rgb_dir]);
+            break;
+         }
+         /* FALLTHROUGH */
+      case 3:
+         stbiw__write3(s, d[1 - rgb_dir], d[1], d[1 + rgb_dir]);
+         break;
+   }
+   if (write_alpha > 0)
+      stbiw__write1(s, d[comp - 1]);
+}
+
+static void stbiw__write_pixels(stbi__write_context *s, int rgb_dir, int vdir, int x, int y, int comp, void *data, int write_alpha, int scanline_pad, int expand_mono)
+{
+   stbiw_uint32 zero = 0;
+   int i,j, j_end;
+
+   if (y <= 0)
+      return;
+
+   if (stbi__flip_vertically_on_write)
+      vdir *= -1;
+
+   if (vdir < 0) {
+      j_end = -1; j = y-1;
+   } else {
+      j_end =  y; j = 0;
+   }
+
+   for (; j != j_end; j += vdir) {
+      for (i=0; i < x; ++i) {
+         unsigned char *d = (unsigned char *) data + (j*x+i)*comp;
+         stbiw__write_pixel(s, rgb_dir, comp, write_alpha, expand_mono, d);
+      }
+      stbiw__write_flush(s);
+      s->func(s->context, &zero, scanline_pad);
+   }
+}
+
+static int stbiw__outfile(stbi__write_context *s, int rgb_dir, int vdir, int x, int y, int comp, int expand_mono, void *data, int alpha, int pad, const char *fmt, ...)
+{
+   if (y < 0 || x < 0) {
+      return 0;
+   } else {
+      va_list v;
+      va_start(v, fmt);
+      stbiw__writefv(s, fmt, v);
+      va_end(v);
+      stbiw__write_pixels(s,rgb_dir,vdir,x,y,comp,data,alpha,pad, expand_mono);
+      return 1;
+   }
+}
+
+static int stbi_write_bmp_core(stbi__write_context *s, int x, int y, int comp, const void *data)
+{
+   if (comp != 4) {
+      // write RGB bitmap
+      int pad = (-x*3) & 3;
+      return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *) data,0,pad,
+              "11 4 22 4" "4 44 22 444444",
+              'B', 'M', 14+40+(x*3+pad)*y, 0,0, 14+40,  // file header
+               40, x,y, 1,24, 0,0,0,0,0,0);             // bitmap header
+   } else {
+      // RGBA bitmaps need a v4 header
+      // use BI_BITFIELDS mode with 32bpp and alpha mask
+      // (straight BI_RGB with alpha mask doesn't work in most readers)
+      return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *)data,1,0,
+         "11 4 22 4" "4 44 22 444444 4444 4 444 444 444 444",
+         'B', 'M', 14+108+x*y*4, 0, 0, 14+108, // file header
+         108, x,y, 1,32, 3,0,0,0,0,0, 0xff0000,0xff00,0xff,0xff000000u, 0, 0,0,0, 0,0,0, 0,0,0, 0,0,0); // bitmap V4 header
+   }
+}
+
+STBIWDEF int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data)
+{
+   stbi__write_context s = { 0 };
+   stbi__start_write_callbacks(&s, func, context);
+   return stbi_write_bmp_core(&s, x, y, comp, data);
+}
+
+#ifndef STBI_WRITE_NO_STDIO
+STBIWDEF int stbi_write_bmp(char const *filename, int x, int y, int comp, const void *data)
+{
+   stbi__write_context s = { 0 };
+   if (stbi__start_write_file(&s,filename)) {
+      int r = stbi_write_bmp_core(&s, x, y, comp, data);
+      stbi__end_write_file(&s);
+      return r;
+   } else
+      return 0;
+}
+#endif //!STBI_WRITE_NO_STDIO
+
+static int stbi_write_tga_core(stbi__write_context *s, int x, int y, int comp, void *data)
+{
+   int has_alpha = (comp == 2 || comp == 4);
+   int colorbytes = has_alpha ? comp-1 : comp;
+   int format = colorbytes < 2 ? 3 : 2; // 3 color channels (RGB/RGBA) = 2, 1 color channel (Y/YA) = 3
+
+   if (y < 0 || x < 0)
+      return 0;
+
+   if (!stbi_write_tga_with_rle) {
+      return stbiw__outfile(s, -1, -1, x, y, comp, 0, (void *) data, has_alpha, 0,
+         "111 221 2222 11", 0, 0, format, 0, 0, 0, 0, 0, x, y, (colorbytes + has_alpha) * 8, has_alpha * 8);
+   } else {
+      int i,j,k;
+      int jend, jdir;
+
+      stbiw__writef(s, "111 221 2222 11", 0,0,format+8, 0,0,0, 0,0,x,y, (colorbytes + has_alpha) * 8, has_alpha * 8);
+
+      if (stbi__flip_vertically_on_write) {
+         j = 0;
+         jend = y;
+         jdir = 1;
+      } else {
+         j = y-1;
+         jend = -1;
+         jdir = -1;
+      }
+      for (; j != jend; j += jdir) {
+         unsigned char *row = (unsigned char *) data + j * x * comp;
+         int len;
+
+         for (i = 0; i < x; i += len) {
+            unsigned char *begin = row + i * comp;
+            int diff = 1;
+            len = 1;
+
+            if (i < x - 1) {
+               ++len;
+               diff = memcmp(begin, row + (i + 1) * comp, comp);
+               if (diff) {
+                  const unsigned char *prev = begin;
+                  for (k = i + 2; k < x && len < 128; ++k) {
+                     if (memcmp(prev, row + k * comp, comp)) {
+                        prev += comp;
+                        ++len;
+                     } else {
+                        --len;
+                        break;
+                     }
+                  }
+               } else {
+                  for (k = i + 2; k < x && len < 128; ++k) {
+                     if (!memcmp(begin, row + k * comp, comp)) {
+                        ++len;
+                     } else {
+                        break;
+                     }
+                  }
+               }
+            }
+
+            if (diff) {
+               unsigned char header = STBIW_UCHAR(len - 1);
+               stbiw__write1(s, header);
+               for (k = 0; k < len; ++k) {
+                  stbiw__write_pixel(s, -1, comp, has_alpha, 0, begin + k * comp);
+               }
+            } else {
+               unsigned char header = STBIW_UCHAR(len - 129);
+               stbiw__write1(s, header);
+               stbiw__write_pixel(s, -1, comp, has_alpha, 0, begin);
+            }
+         }
+      }
+      stbiw__write_flush(s);
+   }
+   return 1;
+}
+
+STBIWDEF int stbi_write_tga_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data)
+{
+   stbi__write_context s = { 0 };
+   stbi__start_write_callbacks(&s, func, context);
+   return stbi_write_tga_core(&s, x, y, comp, (void *) data);
+}
+
+#ifndef STBI_WRITE_NO_STDIO
+STBIWDEF int stbi_write_tga(char const *filename, int x, int y, int comp, const void *data)
+{
+   stbi__write_context s = { 0 };
+   if (stbi__start_write_file(&s,filename)) {
+      int r = stbi_write_tga_core(&s, x, y, comp, (void *) data);
+      stbi__end_write_file(&s);
+      return r;
+   } else
+      return 0;
+}
+#endif
+
+// *************************************************************************************************
+// Radiance RGBE HDR writer
+// by Baldur Karlsson
+
+#define stbiw__max(a, b)  ((a) > (b) ? (a) : (b))
+
+#ifndef STBI_WRITE_NO_STDIO
+
+static void stbiw__linear_to_rgbe(unsigned char *rgbe, float *linear)
+{
+   int exponent;
+   float maxcomp = stbiw__max(linear[0], stbiw__max(linear[1], linear[2]));
+
+   if (maxcomp < 1e-32f) {
+      rgbe[0] = rgbe[1] = rgbe[2] = rgbe[3] = 0;
+   } else {
+      float normalize = (float) frexp(maxcomp, &exponent) * 256.0f/maxcomp;
+
+      rgbe[0] = (unsigned char)(linear[0] * normalize);
+      rgbe[1] = (unsigned char)(linear[1] * normalize);
+      rgbe[2] = (unsigned char)(linear[2] * normalize);
+      rgbe[3] = (unsigned char)(exponent + 128);
+   }
+}
+
+static void stbiw__write_run_data(stbi__write_context *s, int length, unsigned char databyte)
+{
+   unsigned char lengthbyte = STBIW_UCHAR(length+128);
+   STBIW_ASSERT(length+128 <= 255);
+   s->func(s->context, &lengthbyte, 1);
+   s->func(s->context, &databyte, 1);
+}
+
+static void stbiw__write_dump_data(stbi__write_context *s, int length, unsigned char *data)
+{
+   unsigned char lengthbyte = STBIW_UCHAR(length);
+   STBIW_ASSERT(length <= 128); // inconsistent with spec but consistent with official code
+   s->func(s->context, &lengthbyte, 1);
+   s->func(s->context, data, length);
+}
+
+static void stbiw__write_hdr_scanline(stbi__write_context *s, int width, int ncomp, unsigned char *scratch, float *scanline)
+{
+   unsigned char scanlineheader[4] = { 2, 2, 0, 0 };
+   unsigned char rgbe[4];
+   float linear[3];
+   int x;
+
+   scanlineheader[2] = (width&0xff00)>>8;
+   scanlineheader[3] = (width&0x00ff);
+
+   /* skip RLE for images too small or large */
+   if (width < 8 || width >= 32768) {
+      for (x=0; x < width; x++) {
+         switch (ncomp) {
+            case 4: /* fallthrough */
+            case 3: linear[2] = scanline[x*ncomp + 2];
+                    linear[1] = scanline[x*ncomp + 1];
+                    linear[0] = scanline[x*ncomp + 0];
+                    break;
+            default:
+                    linear[0] = linear[1] = linear[2] = scanline[x*ncomp + 0];
+                    break;
+         }
+         stbiw__linear_to_rgbe(rgbe, linear);
+         s->func(s->context, rgbe, 4);
+      }
+   } else {
+      int c,r;
+      /* encode into scratch buffer */
+      for (x=0; x < width; x++) {
+         switch(ncomp) {
+            case 4: /* fallthrough */
+            case 3: linear[2] = scanline[x*ncomp + 2];
+                    linear[1] = scanline[x*ncomp + 1];
+                    linear[0] = scanline[x*ncomp + 0];
+                    break;
+            default:
+                    linear[0] = linear[1] = linear[2] = scanline[x*ncomp + 0];
+                    break;
+         }
+         stbiw__linear_to_rgbe(rgbe, linear);
+         scratch[x + width*0] = rgbe[0];
+         scratch[x + width*1] = rgbe[1];
+         scratch[x + width*2] = rgbe[2];
+         scratch[x + width*3] = rgbe[3];
+      }
+
+      s->func(s->context, scanlineheader, 4);
+
+      /* RLE each component separately */
+      for (c=0; c < 4; c++) {
+         unsigned char *comp = &scratch[width*c];
+
+         x = 0;
+         while (x < width) {
+            // find first run
+            r = x;
+            while (r+2 < width) {
+               if (comp[r] == comp[r+1] && comp[r] == comp[r+2])
+                  break;
+               ++r;
+            }
+            if (r+2 >= width)
+               r = width;
+            // dump up to first run
+            while (x < r) {
+               int len = r-x;
+               if (len > 128) len = 128;
+               stbiw__write_dump_data(s, len, &comp[x]);
+               x += len;
+            }
+            // if there's a run, output it
+            if (r+2 < width) { // same test as what we break out of in search loop, so only true if we break'd
+               // find next byte after run
+               while (r < width && comp[r] == comp[x])
+                  ++r;
+               // output run up to r
+               while (x < r) {
+                  int len = r-x;
+                  if (len > 127) len = 127;
+                  stbiw__write_run_data(s, len, comp[x]);
+                  x += len;
+               }
+            }
+         }
+      }
+   }
+}
+
+static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, float *data)
+{
+   if (y <= 0 || x <= 0 || data == NULL)
+      return 0;
+   else {
+      // Each component is stored separately. Allocate scratch space for full output scanline.
+      unsigned char *scratch = (unsigned char *) STBIW_MALLOC(x*4);
+      int i, len;
+      char buffer[128];
+      char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
+      s->func(s->context, header, sizeof(header)-1);
+
+#ifdef __STDC_LIB_EXT1__
+      len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#else
+      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#endif
+      s->func(s->context, buffer, len);
+
+      for(i=0; i < y; i++)
+         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*x*(stbi__flip_vertically_on_write ? y-1-i : i));
+      STBIW_FREE(scratch);
+      return 1;
+   }
+}
+
+STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const float *data)
+{
+   stbi__write_context s = { 0 };
+   stbi__start_write_callbacks(&s, func, context);
+   return stbi_write_hdr_core(&s, x, y, comp, (float *) data);
+}
+
+STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *data)
+{
+   stbi__write_context s = { 0 };
+   if (stbi__start_write_file(&s,filename)) {
+      int r = stbi_write_hdr_core(&s, x, y, comp, (float *) data);
+      stbi__end_write_file(&s);
+      return r;
+   } else
+      return 0;
+}
+#endif // STBI_WRITE_NO_STDIO
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// PNG writer
+//
+
+#ifndef STBIW_ZLIB_COMPRESS
+// stretchy buffer; stbiw__sbpush() == vector<>::push_back() -- stbiw__sbcount() == vector<>::size()
+#define stbiw__sbraw(a) ((int *) (void *) (a) - 2)
+#define stbiw__sbm(a)   stbiw__sbraw(a)[0]
+#define stbiw__sbn(a)   stbiw__sbraw(a)[1]
+
+#define stbiw__sbneedgrow(a,n)  ((a)==0 || stbiw__sbn(a)+n >= stbiw__sbm(a))
+#define stbiw__sbmaybegrow(a,n) (stbiw__sbneedgrow(a,(n)) ? stbiw__sbgrow(a,n) : 0)
+#define stbiw__sbgrow(a,n)  stbiw__sbgrowf((void **) &(a), (n), sizeof(*(a)))
+
+#define stbiw__sbpush(a, v)      (stbiw__sbmaybegrow(a,1), (a)[stbiw__sbn(a)++] = (v))
+#define stbiw__sbcount(a)        ((a) ? stbiw__sbn(a) : 0)
+#define stbiw__sbfree(a)         ((a) ? STBIW_FREE(stbiw__sbraw(a)),0 : 0)
+
+static void *stbiw__sbgrowf(void **arr, int increment, int itemsize)
+{
+   int m = *arr ? 2*stbiw__sbm(*arr)+increment : increment+1;
+   void *p = STBIW_REALLOC_SIZED(*arr ? stbiw__sbraw(*arr) : 0, *arr ? (stbiw__sbm(*arr)*itemsize + sizeof(int)*2) : 0, itemsize * m + sizeof(int)*2);
+   STBIW_ASSERT(p);
+   if (p) {
+      if (!*arr) ((int *) p)[1] = 0;
+      *arr = (void *) ((int *) p + 2);
+      stbiw__sbm(*arr) = m;
+   }
+   return *arr;
+}
+
+static unsigned char *stbiw__zlib_flushf(unsigned char *data, unsigned int *bitbuffer, int *bitcount)
+{
+   while (*bitcount >= 8) {
+      stbiw__sbpush(data, STBIW_UCHAR(*bitbuffer));
+      *bitbuffer >>= 8;
+      *bitcount -= 8;
+   }
+   return data;
+}
+
+static int stbiw__zlib_bitrev(int code, int codebits)
+{
+   int res=0;
+   while (codebits--) {
+      res = (res << 1) | (code & 1);
+      code >>= 1;
+   }
+   return res;
+}
+
+static unsigned int stbiw__zlib_countm(unsigned char *a, unsigned char *b, int limit)
+{
+   int i;
+   for (i=0; i < limit && i < 258; ++i)
+      if (a[i] != b[i]) break;
+   return i;
+}
+
+static unsigned int stbiw__zhash(unsigned char *data)
+{
+   stbiw_uint32 hash = data[0] + (data[1] << 8) + (data[2] << 16);
+   hash ^= hash << 3;
+   hash += hash >> 5;
+   hash ^= hash << 4;
+   hash += hash >> 17;
+   hash ^= hash << 25;
+   hash += hash >> 6;
+   return hash;
+}
+
+#define stbiw__zlib_flush() (out = stbiw__zlib_flushf(out, &bitbuf, &bitcount))
+#define stbiw__zlib_add(code,codebits) \
+      (bitbuf |= (code) << bitcount, bitcount += (codebits), stbiw__zlib_flush())
+#define stbiw__zlib_huffa(b,c)  stbiw__zlib_add(stbiw__zlib_bitrev(b,c),c)
+// default huffman tables
+#define stbiw__zlib_huff1(n)  stbiw__zlib_huffa(0x30 + (n), 8)
+#define stbiw__zlib_huff2(n)  stbiw__zlib_huffa(0x190 + (n)-144, 9)
+#define stbiw__zlib_huff3(n)  stbiw__zlib_huffa(0 + (n)-256,7)
+#define stbiw__zlib_huff4(n)  stbiw__zlib_huffa(0xc0 + (n)-280,8)
+#define stbiw__zlib_huff(n)  ((n) <= 143 ? stbiw__zlib_huff1(n) : (n) <= 255 ? stbiw__zlib_huff2(n) : (n) <= 279 ? stbiw__zlib_huff3(n) : stbiw__zlib_huff4(n))
+#define stbiw__zlib_huffb(n) ((n) <= 143 ? stbiw__zlib_huff1(n) : stbiw__zlib_huff2(n))
+
+#define stbiw__ZHASH   16384
+
+#endif // STBIW_ZLIB_COMPRESS
+
+STBIWDEF unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_len, int quality)
+{
+#ifdef STBIW_ZLIB_COMPRESS
+   // user provided a zlib compress implementation, use that
+   return STBIW_ZLIB_COMPRESS(data, data_len, out_len, quality);
+#else // use builtin
+   static unsigned short lengthc[] = { 3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258, 259 };
+   static unsigned char  lengtheb[]= { 0,0,0,0,0,0,0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4,  4,  5,  5,  5,  5,  0 };
+   static unsigned short distc[]   = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577, 32768 };
+   static unsigned char  disteb[]  = { 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13 };
+   unsigned int bitbuf=0;
+   int i,j, bitcount=0;
+   unsigned char *out = NULL;
+   unsigned char ***hash_table = (unsigned char***) STBIW_MALLOC(stbiw__ZHASH * sizeof(unsigned char**));
+   if (hash_table == NULL)
+      return NULL;
+   if (quality < 5) quality = 5;
+
+   stbiw__sbpush(out, 0x78);   // DEFLATE 32K window
+   stbiw__sbpush(out, 0x5e);   // FLEVEL = 1
+   stbiw__zlib_add(1,1);  // BFINAL = 1
+   stbiw__zlib_add(1,2);  // BTYPE = 1 -- fixed huffman
+
+   for (i=0; i < stbiw__ZHASH; ++i)
+      hash_table[i] = NULL;
+
+   i=0;
+   while (i < data_len-3) {
+      // hash next 3 bytes of data to be compressed
+      int h = stbiw__zhash(data+i)&(stbiw__ZHASH-1), best=3;
+      unsigned char *bestloc = 0;
+      unsigned char **hlist = hash_table[h];
+      int n = stbiw__sbcount(hlist);
+      for (j=0; j < n; ++j) {
+         if (hlist[j]-data > i-32768) { // if entry lies within window
+            int d = stbiw__zlib_countm(hlist[j], data+i, data_len-i);
+            if (d >= best) { best=d; bestloc=hlist[j]; }
+         }
+      }
+      // when hash table entry is too long, delete half the entries
+      if (hash_table[h] && stbiw__sbn(hash_table[h]) == 2*quality) {
+         STBIW_MEMMOVE(hash_table[h], hash_table[h]+quality, sizeof(hash_table[h][0])*quality);
+         stbiw__sbn(hash_table[h]) = quality;
+      }
+      stbiw__sbpush(hash_table[h],data+i);
+
+      if (bestloc) {
+         // "lazy matching" - check match at *next* byte, and if it's better, do cur byte as literal
+         h = stbiw__zhash(data+i+1)&(stbiw__ZHASH-1);
+         hlist = hash_table[h];
+         n = stbiw__sbcount(hlist);
+         for (j=0; j < n; ++j) {
+            if (hlist[j]-data > i-32767) {
+               int e = stbiw__zlib_countm(hlist[j], data+i+1, data_len-i-1);
+               if (e > best) { // if next match is better, bail on current match
+                  bestloc = NULL;
+                  break;
+               }
+            }
+         }
+      }
+
+      if (bestloc) {
+         int d = (int) (data+i - bestloc); // distance back
+         STBIW_ASSERT(d <= 32767 && best <= 258);
+         for (j=0; best > lengthc[j+1]-1; ++j);
+         stbiw__zlib_huff(j+257);
+         if (lengtheb[j]) stbiw__zlib_add(best - lengthc[j], lengtheb[j]);
+         for (j=0; d > distc[j+1]-1; ++j);
+         stbiw__zlib_add(stbiw__zlib_bitrev(j,5),5);
+         if (disteb[j]) stbiw__zlib_add(d - distc[j], disteb[j]);
+         i += best;
+      } else {
+         stbiw__zlib_huffb(data[i]);
+         ++i;
+      }
+   }
+   // write out final bytes
+   for (;i < data_len; ++i)
+      stbiw__zlib_huffb(data[i]);
+   stbiw__zlib_huff(256); // end of block
+   // pad with 0 bits to byte boundary
+   while (bitcount)
+      stbiw__zlib_add(0,1);
+
+   for (i=0; i < stbiw__ZHASH; ++i)
+      (void) stbiw__sbfree(hash_table[i]);
+   STBIW_FREE(hash_table);
+
+   // store uncompressed instead if compression was worse
+   if (stbiw__sbn(out) > data_len + 2 + ((data_len+32766)/32767)*5) {
+      stbiw__sbn(out) = 2;  // truncate to DEFLATE 32K window and FLEVEL = 1
+      for (j = 0; j < data_len;) {
+         int blocklen = data_len - j;
+         if (blocklen > 32767) blocklen = 32767;
+         stbiw__sbpush(out, data_len - j == blocklen); // BFINAL = ?, BTYPE = 0 -- no compression
+         stbiw__sbpush(out, STBIW_UCHAR(blocklen)); // LEN
+         stbiw__sbpush(out, STBIW_UCHAR(blocklen >> 8));
+         stbiw__sbpush(out, STBIW_UCHAR(~blocklen)); // NLEN
+         stbiw__sbpush(out, STBIW_UCHAR(~blocklen >> 8));
+         memcpy(out+stbiw__sbn(out), data+j, blocklen);
+         stbiw__sbn(out) += blocklen;
+         j += blocklen;
+      }
+   }
+
+   {
+      // compute adler32 on input
+      unsigned int s1=1, s2=0;
+      int blocklen = (int) (data_len % 5552);
+      j=0;
+      while (j < data_len) {
+         for (i=0; i < blocklen; ++i) { s1 += data[j+i]; s2 += s1; }
+         s1 %= 65521; s2 %= 65521;
+         j += blocklen;
+         blocklen = 5552;
+      }
+      stbiw__sbpush(out, STBIW_UCHAR(s2 >> 8));
+      stbiw__sbpush(out, STBIW_UCHAR(s2));
+      stbiw__sbpush(out, STBIW_UCHAR(s1 >> 8));
+      stbiw__sbpush(out, STBIW_UCHAR(s1));
+   }
+   *out_len = stbiw__sbn(out);
+   // make returned pointer freeable
+   STBIW_MEMMOVE(stbiw__sbraw(out), out, *out_len);
+   return (unsigned char *) stbiw__sbraw(out);
+#endif // STBIW_ZLIB_COMPRESS
+}
+
+static unsigned int stbiw__crc32(unsigned char *buffer, int len)
+{
+#ifdef STBIW_CRC32
+    return STBIW_CRC32(buffer, len);
+#else
+   static unsigned int crc_table[256] =
+   {
+      0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+      0x0eDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+      0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+      0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+      0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+      0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+      0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+      0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+      0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+      0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+      0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+      0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+      0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+      0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+      0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+      0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+      0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+      0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+      0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+      0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+      0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+      0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+      0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+      0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+      0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+      0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+      0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+      0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+      0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+      0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+      0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+      0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
+   };
+
+   unsigned int crc = ~0u;
+   int i;
+   for (i=0; i < len; ++i)
+      crc = (crc >> 8) ^ crc_table[buffer[i] ^ (crc & 0xff)];
+   return ~crc;
+#endif
+}
+
+#define stbiw__wpng4(o,a,b,c,d) ((o)[0]=STBIW_UCHAR(a),(o)[1]=STBIW_UCHAR(b),(o)[2]=STBIW_UCHAR(c),(o)[3]=STBIW_UCHAR(d),(o)+=4)
+#define stbiw__wp32(data,v) stbiw__wpng4(data, (v)>>24,(v)>>16,(v)>>8,(v));
+#define stbiw__wptag(data,s) stbiw__wpng4(data, s[0],s[1],s[2],s[3])
+
+static void stbiw__wpcrc(unsigned char **data, int len)
+{
+   unsigned int crc = stbiw__crc32(*data - len - 4, len+4);
+   stbiw__wp32(*data, crc);
+}
+
+static unsigned char stbiw__paeth(int a, int b, int c)
+{
+   int p = a + b - c, pa = abs(p-a), pb = abs(p-b), pc = abs(p-c);
+   if (pa <= pb && pa <= pc) return STBIW_UCHAR(a);
+   if (pb <= pc) return STBIW_UCHAR(b);
+   return STBIW_UCHAR(c);
+}
+
+// @OPTIMIZE: provide an option that always forces left-predict or paeth predict
+static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes, int width, int height, int y, int n, int filter_type, signed char *line_buffer)
+{
+   static int mapping[] = { 0,1,2,3,4 };
+   static int firstmap[] = { 0,1,0,5,6 };
+   int *mymap = (y != 0) ? mapping : firstmap;
+   int i;
+   int type = mymap[filter_type];
+   unsigned char *z = pixels + stride_bytes * (stbi__flip_vertically_on_write ? height-1-y : y);
+   int signed_stride = stbi__flip_vertically_on_write ? -stride_bytes : stride_bytes;
+
+   if (type==0) {
+      memcpy(line_buffer, z, width*n);
+      return;
+   }
+
+   // first loop isn't optimized since it's just one pixel
+   for (i = 0; i < n; ++i) {
+      switch (type) {
+         case 1: line_buffer[i] = z[i]; break;
+         case 2: line_buffer[i] = z[i] - z[i-signed_stride]; break;
+         case 3: line_buffer[i] = z[i] - (z[i-signed_stride]>>1); break;
+         case 4: line_buffer[i] = (signed char) (z[i] - stbiw__paeth(0,z[i-signed_stride],0)); break;
+         case 5: line_buffer[i] = z[i]; break;
+         case 6: line_buffer[i] = z[i]; break;
+      }
+   }
+   switch (type) {
+      case 1: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - z[i-n]; break;
+      case 2: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - z[i-signed_stride]; break;
+      case 3: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - ((z[i-n] + z[i-signed_stride])>>1); break;
+      case 4: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - stbiw__paeth(z[i-n], z[i-signed_stride], z[i-signed_stride-n]); break;
+      case 5: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - (z[i-n]>>1); break;
+      case 6: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - stbiw__paeth(z[i-n], 0,0); break;
+   }
+}
+
+STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int stride_bytes, int x, int y, int n, int *out_len)
+{
+   int force_filter = stbi_write_force_png_filter;
+   int ctype[5] = { -1, 0, 4, 2, 6 };
+   unsigned char sig[8] = { 137,80,78,71,13,10,26,10 };
+   unsigned char *out,*o, *filt, *zlib;
+   signed char *line_buffer;
+   int j,zlen;
+
+   if (stride_bytes == 0)
+      stride_bytes = x * n;
+
+   if (force_filter >= 5) {
+      force_filter = -1;
+   }
+
+   filt = (unsigned char *) STBIW_MALLOC((x*n+1) * y); if (!filt) return 0;
+   line_buffer = (signed char *) STBIW_MALLOC(x * n); if (!line_buffer) { STBIW_FREE(filt); return 0; }
+   for (j=0; j < y; ++j) {
+      int filter_type;
+      if (force_filter > -1) {
+         filter_type = force_filter;
+         stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, force_filter, line_buffer);
+      } else { // Estimate the best filter by running through all of them:
+         int best_filter = 0, best_filter_val = 0x7fffffff, est, i;
+         for (filter_type = 0; filter_type < 5; filter_type++) {
+            stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, filter_type, line_buffer);
+
+            // Estimate the entropy of the line using this filter; the less, the better.
+            est = 0;
+            for (i = 0; i < x*n; ++i) {
+               est += abs((signed char) line_buffer[i]);
+            }
+            if (est < best_filter_val) {
+               best_filter_val = est;
+               best_filter = filter_type;
+            }
+         }
+         if (filter_type != best_filter) {  // If the last iteration already got us the best filter, don't redo it
+            stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, best_filter, line_buffer);
+            filter_type = best_filter;
+         }
+      }
+      // when we get here, filter_type contains the filter type, and line_buffer contains the data
+      filt[j*(x*n+1)] = (unsigned char) filter_type;
+      STBIW_MEMMOVE(filt+j*(x*n+1)+1, line_buffer, x*n);
+   }
+   STBIW_FREE(line_buffer);
+   zlib = stbi_zlib_compress(filt, y*( x*n+1), &zlen, stbi_write_png_compression_level);
+   STBIW_FREE(filt);
+   if (!zlib) return 0;
+
+   // each tag requires 12 bytes of overhead
+   out = (unsigned char *) STBIW_MALLOC(8 + 12+13 + 12+zlen + 12);
+   if (!out) return 0;
+   *out_len = 8 + 12+13 + 12+zlen + 12;
+
+   o=out;
+   STBIW_MEMMOVE(o,sig,8); o+= 8;
+   stbiw__wp32(o, 13); // header length
+   stbiw__wptag(o, "IHDR");
+   stbiw__wp32(o, x);
+   stbiw__wp32(o, y);
+   *o++ = 8;
+   *o++ = STBIW_UCHAR(ctype[n]);
+   *o++ = 0;
+   *o++ = 0;
+   *o++ = 0;
+   stbiw__wpcrc(&o,13);
+
+   stbiw__wp32(o, zlen);
+   stbiw__wptag(o, "IDAT");
+   STBIW_MEMMOVE(o, zlib, zlen);
+   o += zlen;
+   STBIW_FREE(zlib);
+   stbiw__wpcrc(&o, zlen);
+
+   stbiw__wp32(o,0);
+   stbiw__wptag(o, "IEND");
+   stbiw__wpcrc(&o,0);
+
+   STBIW_ASSERT(o == out + *out_len);
+
+   return out;
+}
+
+#ifndef STBI_WRITE_NO_STDIO
+STBIWDEF int stbi_write_png(char const *filename, int x, int y, int comp, const void *data, int stride_bytes)
+{
+   FILE *f;
+   int len;
+   unsigned char *png = stbi_write_png_to_mem((const unsigned char *) data, stride_bytes, x, y, comp, &len);
+   if (png == NULL) return 0;
+
+   f = stbiw__fopen(filename, "wb");
+   if (!f) { STBIW_FREE(png); return 0; }
+   fwrite(png, 1, len, f);
+   fclose(f);
+   STBIW_FREE(png);
+   return 1;
+}
+#endif
+
+STBIWDEF int stbi_write_png_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int stride_bytes)
+{
+   int len;
+   unsigned char *png = stbi_write_png_to_mem((const unsigned char *) data, stride_bytes, x, y, comp, &len);
+   if (png == NULL) return 0;
+   func(context, png, len);
+   STBIW_FREE(png);
+   return 1;
+}
+
+
+/* ***************************************************************************
+ *
+ * JPEG writer
+ *
+ * This is based on Jon Olick's jo_jpeg.cpp:
+ * public domain Simple, Minimalistic JPEG writer - http://www.jonolick.com/code.html
+ */
+
+static const unsigned char stbiw__jpg_ZigZag[] = { 0,1,5,6,14,15,27,28,2,4,7,13,16,26,29,42,3,8,12,17,25,30,41,43,9,11,18,
+      24,31,40,44,53,10,19,23,32,39,45,52,54,20,22,33,38,46,51,55,60,21,34,37,47,50,56,59,61,35,36,48,49,57,58,62,63 };
+
+static void stbiw__jpg_writeBits(stbi__write_context *s, int *bitBufP, int *bitCntP, const unsigned short *bs) {
+   int bitBuf = *bitBufP, bitCnt = *bitCntP;
+   bitCnt += bs[1];
+   bitBuf |= bs[0] << (24 - bitCnt);
+   while(bitCnt >= 8) {
+      unsigned char c = (bitBuf >> 16) & 255;
+      stbiw__putc(s, c);
+      if(c == 255) {
+         stbiw__putc(s, 0);
+      }
+      bitBuf <<= 8;
+      bitCnt -= 8;
+   }
+   *bitBufP = bitBuf;
+   *bitCntP = bitCnt;
+}
+
+static void stbiw__jpg_DCT(float *d0p, float *d1p, float *d2p, float *d3p, float *d4p, float *d5p, float *d6p, float *d7p) {
+   float d0 = *d0p, d1 = *d1p, d2 = *d2p, d3 = *d3p, d4 = *d4p, d5 = *d5p, d6 = *d6p, d7 = *d7p;
+   float z1, z2, z3, z4, z5, z11, z13;
+
+   float tmp0 = d0 + d7;
+   float tmp7 = d0 - d7;
+   float tmp1 = d1 + d6;
+   float tmp6 = d1 - d6;
+   float tmp2 = d2 + d5;
+   float tmp5 = d2 - d5;
+   float tmp3 = d3 + d4;
+   float tmp4 = d3 - d4;
+
+   // Even part
+   float tmp10 = tmp0 + tmp3;   // phase 2
+   float tmp13 = tmp0 - tmp3;
+   float tmp11 = tmp1 + tmp2;
+   float tmp12 = tmp1 - tmp2;
+
+   d0 = tmp10 + tmp11;       // phase 3
+   d4 = tmp10 - tmp11;
+
+   z1 = (tmp12 + tmp13) * 0.707106781f; // c4
+   d2 = tmp13 + z1;       // phase 5
+   d6 = tmp13 - z1;
+
+   // Odd part
+   tmp10 = tmp4 + tmp5;       // phase 2
+   tmp11 = tmp5 + tmp6;
+   tmp12 = tmp6 + tmp7;
+
+   // The rotator is modified from fig 4-8 to avoid extra negations.
+   z5 = (tmp10 - tmp12) * 0.382683433f; // c6
+   z2 = tmp10 * 0.541196100f + z5; // c2-c6
+   z4 = tmp12 * 1.306562965f + z5; // c2+c6
+   z3 = tmp11 * 0.707106781f; // c4
+
+   z11 = tmp7 + z3;      // phase 5
+   z13 = tmp7 - z3;
+
+   *d5p = z13 + z2;         // phase 6
+   *d3p = z13 - z2;
+   *d1p = z11 + z4;
+   *d7p = z11 - z4;
+
+   *d0p = d0;  *d2p = d2;  *d4p = d4;  *d6p = d6;
+}
+
+static void stbiw__jpg_calcBits(int val, unsigned short bits[2]) {
+   int tmp1 = val < 0 ? -val : val;
+   val = val < 0 ? val-1 : val;
+   bits[1] = 1;
+   while(tmp1 >>= 1) {
+      ++bits[1];
+   }
+   bits[0] = val & ((1<<bits[1])-1);
+}
+
+static int stbiw__jpg_processDU(stbi__write_context *s, int *bitBuf, int *bitCnt, float *CDU, int du_stride, float *fdtbl, int DC, const unsigned short HTDC[256][2], const unsigned short HTAC[256][2]) {
+   const unsigned short EOB[2] = { HTAC[0x00][0], HTAC[0x00][1] };
+   const unsigned short M16zeroes[2] = { HTAC[0xF0][0], HTAC[0xF0][1] };
+   int dataOff, i, j, n, diff, end0pos, x, y;
+   int DU[64];
+
+   // DCT rows
+   for(dataOff=0, n=du_stride*8; dataOff<n; dataOff+=du_stride) {
+      stbiw__jpg_DCT(&CDU[dataOff], &CDU[dataOff+1], &CDU[dataOff+2], &CDU[dataOff+3], &CDU[dataOff+4], &CDU[dataOff+5], &CDU[dataOff+6], &CDU[dataOff+7]);
+   }
+   // DCT columns
+   for(dataOff=0; dataOff<8; ++dataOff) {
+      stbiw__jpg_DCT(&CDU[dataOff], &CDU[dataOff+du_stride], &CDU[dataOff+du_stride*2], &CDU[dataOff+du_stride*3], &CDU[dataOff+du_stride*4],
+                     &CDU[dataOff+du_stride*5], &CDU[dataOff+du_stride*6], &CDU[dataOff+du_stride*7]);
+   }
+   // Quantize/descale/zigzag the coefficients
+   for(y = 0, j=0; y < 8; ++y) {
+      for(x = 0; x < 8; ++x,++j) {
+         float v;
+         i = y*du_stride+x;
+         v = CDU[i]*fdtbl[j];
+         // DU[stbiw__jpg_ZigZag[j]] = (int)(v < 0 ? ceilf(v - 0.5f) : floorf(v + 0.5f));
+         // ceilf() and floorf() are C99, not C89, but I /think/ they're not needed here anyway?
+         DU[stbiw__jpg_ZigZag[j]] = (int)(v < 0 ? v - 0.5f : v + 0.5f);
+      }
+   }
+
+   // Encode DC
+   diff = DU[0] - DC;
+   if (diff == 0) {
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, HTDC[0]);
+   } else {
+      unsigned short bits[2];
+      stbiw__jpg_calcBits(diff, bits);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, HTDC[bits[1]]);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, bits);
+   }
+   // Encode ACs
+   end0pos = 63;
+   for(; (end0pos>0)&&(DU[end0pos]==0); --end0pos) {
+   }
+   // end0pos = first element in reverse order !=0
+   if(end0pos == 0) {
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, EOB);
+      return DU[0];
+   }
+   for(i = 1; i <= end0pos; ++i) {
+      int startpos = i;
+      int nrzeroes;
+      unsigned short bits[2];
+      for (; DU[i]==0 && i<=end0pos; ++i) {
+      }
+      nrzeroes = i-startpos;
+      if ( nrzeroes >= 16 ) {
+         int lng = nrzeroes>>4;
+         int nrmarker;
+         for (nrmarker=1; nrmarker <= lng; ++nrmarker)
+            stbiw__jpg_writeBits(s, bitBuf, bitCnt, M16zeroes);
+         nrzeroes &= 15;
+      }
+      stbiw__jpg_calcBits(DU[i], bits);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, HTAC[(nrzeroes<<4)+bits[1]]);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, bits);
+   }
+   if(end0pos != 63) {
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, EOB);
+   }
+   return DU[0];
+}
+
+static int stbi_write_jpg_core(stbi__write_context *s, int width, int height, int comp, const void* data, int quality) {
+   // Constants that don't pollute global namespace
+   static const unsigned char std_dc_luminance_nrcodes[] = {0,0,1,5,1,1,1,1,1,1,0,0,0,0,0,0,0};
+   static const unsigned char std_dc_luminance_values[] = {0,1,2,3,4,5,6,7,8,9,10,11};
+   static const unsigned char std_ac_luminance_nrcodes[] = {0,0,2,1,3,3,2,4,3,5,5,4,4,0,0,1,0x7d};
+   static const unsigned char std_ac_luminance_values[] = {
+      0x01,0x02,0x03,0x00,0x04,0x11,0x05,0x12,0x21,0x31,0x41,0x06,0x13,0x51,0x61,0x07,0x22,0x71,0x14,0x32,0x81,0x91,0xa1,0x08,
+      0x23,0x42,0xb1,0xc1,0x15,0x52,0xd1,0xf0,0x24,0x33,0x62,0x72,0x82,0x09,0x0a,0x16,0x17,0x18,0x19,0x1a,0x25,0x26,0x27,0x28,
+      0x29,0x2a,0x34,0x35,0x36,0x37,0x38,0x39,0x3a,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4a,0x53,0x54,0x55,0x56,0x57,0x58,0x59,
+      0x5a,0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6a,0x73,0x74,0x75,0x76,0x77,0x78,0x79,0x7a,0x83,0x84,0x85,0x86,0x87,0x88,0x89,
+      0x8a,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,0x9a,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xb2,0xb3,0xb4,0xb5,0xb6,
+      0xb7,0xb8,0xb9,0xba,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xe1,0xe2,
+      0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa
+   };
+   static const unsigned char std_dc_chrominance_nrcodes[] = {0,0,3,1,1,1,1,1,1,1,1,1,0,0,0,0,0};
+   static const unsigned char std_dc_chrominance_values[] = {0,1,2,3,4,5,6,7,8,9,10,11};
+   static const unsigned char std_ac_chrominance_nrcodes[] = {0,0,2,1,2,4,4,3,4,7,5,4,4,0,1,2,0x77};
+   static const unsigned char std_ac_chrominance_values[] = {
+      0x00,0x01,0x02,0x03,0x11,0x04,0x05,0x21,0x31,0x06,0x12,0x41,0x51,0x07,0x61,0x71,0x13,0x22,0x32,0x81,0x08,0x14,0x42,0x91,
+      0xa1,0xb1,0xc1,0x09,0x23,0x33,0x52,0xf0,0x15,0x62,0x72,0xd1,0x0a,0x16,0x24,0x34,0xe1,0x25,0xf1,0x17,0x18,0x19,0x1a,0x26,
+      0x27,0x28,0x29,0x2a,0x35,0x36,0x37,0x38,0x39,0x3a,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4a,0x53,0x54,0x55,0x56,0x57,0x58,
+      0x59,0x5a,0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6a,0x73,0x74,0x75,0x76,0x77,0x78,0x79,0x7a,0x82,0x83,0x84,0x85,0x86,0x87,
+      0x88,0x89,0x8a,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,0x9a,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xb2,0xb3,0xb4,
+      0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,
+      0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa
+   };
+   // Huffman tables
+   static const unsigned short YDC_HT[256][2] = { {0,2},{2,3},{3,3},{4,3},{5,3},{6,3},{14,4},{30,5},{62,6},{126,7},{254,8},{510,9}};
+   static const unsigned short UVDC_HT[256][2] = { {0,2},{1,2},{2,2},{6,3},{14,4},{30,5},{62,6},{126,7},{254,8},{510,9},{1022,10},{2046,11}};
+   static const unsigned short YAC_HT[256][2] = {
+      {10,4},{0,2},{1,2},{4,3},{11,4},{26,5},{120,7},{248,8},{1014,10},{65410,16},{65411,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {12,4},{27,5},{121,7},{502,9},{2038,11},{65412,16},{65413,16},{65414,16},{65415,16},{65416,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {28,5},{249,8},{1015,10},{4084,12},{65417,16},{65418,16},{65419,16},{65420,16},{65421,16},{65422,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {58,6},{503,9},{4085,12},{65423,16},{65424,16},{65425,16},{65426,16},{65427,16},{65428,16},{65429,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {59,6},{1016,10},{65430,16},{65431,16},{65432,16},{65433,16},{65434,16},{65435,16},{65436,16},{65437,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {122,7},{2039,11},{65438,16},{65439,16},{65440,16},{65441,16},{65442,16},{65443,16},{65444,16},{65445,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {123,7},{4086,12},{65446,16},{65447,16},{65448,16},{65449,16},{65450,16},{65451,16},{65452,16},{65453,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {250,8},{4087,12},{65454,16},{65455,16},{65456,16},{65457,16},{65458,16},{65459,16},{65460,16},{65461,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {504,9},{32704,15},{65462,16},{65463,16},{65464,16},{65465,16},{65466,16},{65467,16},{65468,16},{65469,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {505,9},{65470,16},{65471,16},{65472,16},{65473,16},{65474,16},{65475,16},{65476,16},{65477,16},{65478,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {506,9},{65479,16},{65480,16},{65481,16},{65482,16},{65483,16},{65484,16},{65485,16},{65486,16},{65487,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {1017,10},{65488,16},{65489,16},{65490,16},{65491,16},{65492,16},{65493,16},{65494,16},{65495,16},{65496,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {1018,10},{65497,16},{65498,16},{65499,16},{65500,16},{65501,16},{65502,16},{65503,16},{65504,16},{65505,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {2040,11},{65506,16},{65507,16},{65508,16},{65509,16},{65510,16},{65511,16},{65512,16},{65513,16},{65514,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {65515,16},{65516,16},{65517,16},{65518,16},{65519,16},{65520,16},{65521,16},{65522,16},{65523,16},{65524,16},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {2041,11},{65525,16},{65526,16},{65527,16},{65528,16},{65529,16},{65530,16},{65531,16},{65532,16},{65533,16},{65534,16},{0,0},{0,0},{0,0},{0,0},{0,0}
+   };
+   static const unsigned short UVAC_HT[256][2] = {
+      {0,2},{1,2},{4,3},{10,4},{24,5},{25,5},{56,6},{120,7},{500,9},{1014,10},{4084,12},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {11,4},{57,6},{246,8},{501,9},{2038,11},{4085,12},{65416,16},{65417,16},{65418,16},{65419,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {26,5},{247,8},{1015,10},{4086,12},{32706,15},{65420,16},{65421,16},{65422,16},{65423,16},{65424,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {27,5},{248,8},{1016,10},{4087,12},{65425,16},{65426,16},{65427,16},{65428,16},{65429,16},{65430,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {58,6},{502,9},{65431,16},{65432,16},{65433,16},{65434,16},{65435,16},{65436,16},{65437,16},{65438,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {59,6},{1017,10},{65439,16},{65440,16},{65441,16},{65442,16},{65443,16},{65444,16},{65445,16},{65446,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {121,7},{2039,11},{65447,16},{65448,16},{65449,16},{65450,16},{65451,16},{65452,16},{65453,16},{65454,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {122,7},{2040,11},{65455,16},{65456,16},{65457,16},{65458,16},{65459,16},{65460,16},{65461,16},{65462,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {249,8},{65463,16},{65464,16},{65465,16},{65466,16},{65467,16},{65468,16},{65469,16},{65470,16},{65471,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {503,9},{65472,16},{65473,16},{65474,16},{65475,16},{65476,16},{65477,16},{65478,16},{65479,16},{65480,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {504,9},{65481,16},{65482,16},{65483,16},{65484,16},{65485,16},{65486,16},{65487,16},{65488,16},{65489,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {505,9},{65490,16},{65491,16},{65492,16},{65493,16},{65494,16},{65495,16},{65496,16},{65497,16},{65498,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {506,9},{65499,16},{65500,16},{65501,16},{65502,16},{65503,16},{65504,16},{65505,16},{65506,16},{65507,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {2041,11},{65508,16},{65509,16},{65510,16},{65511,16},{65512,16},{65513,16},{65514,16},{65515,16},{65516,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {16352,14},{65517,16},{65518,16},{65519,16},{65520,16},{65521,16},{65522,16},{65523,16},{65524,16},{65525,16},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {1018,10},{32707,15},{65526,16},{65527,16},{65528,16},{65529,16},{65530,16},{65531,16},{65532,16},{65533,16},{65534,16},{0,0},{0,0},{0,0},{0,0},{0,0}
+   };
+   static const int YQT[] = {16,11,10,16,24,40,51,61,12,12,14,19,26,58,60,55,14,13,16,24,40,57,69,56,14,17,22,29,51,87,80,62,18,22,
+                             37,56,68,109,103,77,24,35,55,64,81,104,113,92,49,64,78,87,103,121,120,101,72,92,95,98,112,100,103,99};
+   static const int UVQT[] = {17,18,24,47,99,99,99,99,18,21,26,66,99,99,99,99,24,26,56,99,99,99,99,99,47,66,99,99,99,99,99,99,
+                              99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99};
+   static const float aasf[] = { 1.0f * 2.828427125f, 1.387039845f * 2.828427125f, 1.306562965f * 2.828427125f, 1.175875602f * 2.828427125f,
+                                 1.0f * 2.828427125f, 0.785694958f * 2.828427125f, 0.541196100f * 2.828427125f, 0.275899379f * 2.828427125f };
+
+   int row, col, i, k, subsample;
+   float fdtbl_Y[64], fdtbl_UV[64];
+   unsigned char YTable[64], UVTable[64];
+
+   if(!data || !width || !height || comp > 4 || comp < 1) {
+      return 0;
+   }
+
+   quality = quality ? quality : 90;
+   subsample = quality <= 90 ? 1 : 0;
+   quality = quality < 1 ? 1 : quality > 100 ? 100 : quality;
+   quality = quality < 50 ? 5000 / quality : 200 - quality * 2;
+
+   for(i = 0; i < 64; ++i) {
+      int uvti, yti = (YQT[i]*quality+50)/100;
+      YTable[stbiw__jpg_ZigZag[i]] = (unsigned char) (yti < 1 ? 1 : yti > 255 ? 255 : yti);
+      uvti = (UVQT[i]*quality+50)/100;
+      UVTable[stbiw__jpg_ZigZag[i]] = (unsigned char) (uvti < 1 ? 1 : uvti > 255 ? 255 : uvti);
+   }
+
+   for(row = 0, k = 0; row < 8; ++row) {
+      for(col = 0; col < 8; ++col, ++k) {
+         fdtbl_Y[k]  = 1 / (YTable [stbiw__jpg_ZigZag[k]] * aasf[row] * aasf[col]);
+         fdtbl_UV[k] = 1 / (UVTable[stbiw__jpg_ZigZag[k]] * aasf[row] * aasf[col]);
+      }
+   }
+
+   // Write Headers
+   {
+      static const unsigned char head0[] = { 0xFF,0xD8,0xFF,0xE0,0,0x10,'J','F','I','F',0,1,1,0,0,1,0,1,0,0,0xFF,0xDB,0,0x84,0 };
+      static const unsigned char head2[] = { 0xFF,0xDA,0,0xC,3,1,0,2,0x11,3,0x11,0,0x3F,0 };
+      const unsigned char head1[] = { 0xFF,0xC0,0,0x11,8,(unsigned char)(height>>8),STBIW_UCHAR(height),(unsigned char)(width>>8),STBIW_UCHAR(width),
+                                      3,1,(unsigned char)(subsample?0x22:0x11),0,2,0x11,1,3,0x11,1,0xFF,0xC4,0x01,0xA2,0 };
+      s->func(s->context, (void*)head0, sizeof(head0));
+      s->func(s->context, (void*)YTable, sizeof(YTable));
+      stbiw__putc(s, 1);
+      s->func(s->context, UVTable, sizeof(UVTable));
+      s->func(s->context, (void*)head1, sizeof(head1));
+      s->func(s->context, (void*)(std_dc_luminance_nrcodes+1), sizeof(std_dc_luminance_nrcodes)-1);
+      s->func(s->context, (void*)std_dc_luminance_values, sizeof(std_dc_luminance_values));
+      stbiw__putc(s, 0x10); // HTYACinfo
+      s->func(s->context, (void*)(std_ac_luminance_nrcodes+1), sizeof(std_ac_luminance_nrcodes)-1);
+      s->func(s->context, (void*)std_ac_luminance_values, sizeof(std_ac_luminance_values));
+      stbiw__putc(s, 1); // HTUDCinfo
+      s->func(s->context, (void*)(std_dc_chrominance_nrcodes+1), sizeof(std_dc_chrominance_nrcodes)-1);
+      s->func(s->context, (void*)std_dc_chrominance_values, sizeof(std_dc_chrominance_values));
+      stbiw__putc(s, 0x11); // HTUACinfo
+      s->func(s->context, (void*)(std_ac_chrominance_nrcodes+1), sizeof(std_ac_chrominance_nrcodes)-1);
+      s->func(s->context, (void*)std_ac_chrominance_values, sizeof(std_ac_chrominance_values));
+      s->func(s->context, (void*)head2, sizeof(head2));
+   }
+
+   // Encode 8x8 macroblocks
+   {
+      static const unsigned short fillBits[] = {0x7F, 7};
+      int DCY=0, DCU=0, DCV=0;
+      int bitBuf=0, bitCnt=0;
+      // comp == 2 is grey+alpha (alpha is ignored)
+      int ofsG = comp > 2 ? 1 : 0, ofsB = comp > 2 ? 2 : 0;
+      const unsigned char *dataR = (const unsigned char *)data;
+      const unsigned char *dataG = dataR + ofsG;
+      const unsigned char *dataB = dataR + ofsB;
+      int x, y, pos;
+      if(subsample) {
+         for(y = 0; y < height; y += 16) {
+            for(x = 0; x < width; x += 16) {
+               float Y[256], U[256], V[256];
+               for(row = y, pos = 0; row < y+16; ++row) {
+                  // row >= height => use last input row
+                  int clamped_row = (row < height) ? row : height - 1;
+                  int base_p = (stbi__flip_vertically_on_write ? (height-1-clamped_row) : clamped_row)*width*comp;
+                  for(col = x; col < x+16; ++col, ++pos) {
+                     // if col >= width => use pixel from last input column
+                     int p = base_p + ((col < width) ? col : (width-1))*comp;
+                     float r = dataR[p], g = dataG[p], b = dataB[p];
+                     Y[pos]= +0.29900f*r + 0.58700f*g + 0.11400f*b - 128;
+                     U[pos]= -0.16874f*r - 0.33126f*g + 0.50000f*b;
+                     V[pos]= +0.50000f*r - 0.41869f*g - 0.08131f*b;
+                  }
+               }
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+0,   16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+8,   16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+128, 16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+136, 16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+
+               // subsample U,V
+               {
+                  float subU[64], subV[64];
+                  int yy, xx;
+                  for(yy = 0, pos = 0; yy < 8; ++yy) {
+                     for(xx = 0; xx < 8; ++xx, ++pos) {
+                        int j = yy*32+xx*2;
+                        subU[pos] = (U[j+0] + U[j+1] + U[j+16] + U[j+17]) * 0.25f;
+                        subV[pos] = (V[j+0] + V[j+1] + V[j+16] + V[j+17]) * 0.25f;
+                     }
+                  }
+                  DCU = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, subU, 8, fdtbl_UV, DCU, UVDC_HT, UVAC_HT);
+                  DCV = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, subV, 8, fdtbl_UV, DCV, UVDC_HT, UVAC_HT);
+               }
+            }
+         }
+      } else {
+         for(y = 0; y < height; y += 8) {
+            for(x = 0; x < width; x += 8) {
+               float Y[64], U[64], V[64];
+               for(row = y, pos = 0; row < y+8; ++row) {
+                  // row >= height => use last input row
+                  int clamped_row = (row < height) ? row : height - 1;
+                  int base_p = (stbi__flip_vertically_on_write ? (height-1-clamped_row) : clamped_row)*width*comp;
+                  for(col = x; col < x+8; ++col, ++pos) {
+                     // if col >= width => use pixel from last input column
+                     int p = base_p + ((col < width) ? col : (width-1))*comp;
+                     float r = dataR[p], g = dataG[p], b = dataB[p];
+                     Y[pos]= +0.29900f*r + 0.58700f*g + 0.11400f*b - 128;
+                     U[pos]= -0.16874f*r - 0.33126f*g + 0.50000f*b;
+                     V[pos]= +0.50000f*r - 0.41869f*g - 0.08131f*b;
+                  }
+               }
+
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y, 8, fdtbl_Y,  DCY, YDC_HT, YAC_HT);
+               DCU = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, U, 8, fdtbl_UV, DCU, UVDC_HT, UVAC_HT);
+               DCV = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, V, 8, fdtbl_UV, DCV, UVDC_HT, UVAC_HT);
+            }
+         }
+      }
+
+      // Do the bit alignment of the EOI marker
+      stbiw__jpg_writeBits(s, &bitBuf, &bitCnt, fillBits);
+   }
+
+   // EOI
+   stbiw__putc(s, 0xFF);
+   stbiw__putc(s, 0xD9);
+
+   return 1;
+}
+
+STBIWDEF int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int quality)
+{
+   stbi__write_context s = { 0 };
+   stbi__start_write_callbacks(&s, func, context);
+   return stbi_write_jpg_core(&s, x, y, comp, (void *) data, quality);
+}
+
+
+#ifndef STBI_WRITE_NO_STDIO
+STBIWDEF int stbi_write_jpg(char const *filename, int x, int y, int comp, const void *data, int quality)
+{
+   stbi__write_context s = { 0 };
+   if (stbi__start_write_file(&s,filename)) {
+      int r = stbi_write_jpg_core(&s, x, y, comp, data, quality);
+      stbi__end_write_file(&s);
+      return r;
+   } else
+      return 0;
+}
+#endif
+
+#endif // STB_IMAGE_WRITE_IMPLEMENTATION
+
+/* Revision history
+      1.16  (2021-07-11)
+             make Deflate code emit uncompressed blocks when it would otherwise expand
+             support writing BMPs with alpha channel
+      1.15  (2020-07-13) unknown
+      1.14  (2020-02-02) updated JPEG writer to downsample chroma channels
+      1.13
+      1.12
+      1.11  (2019-08-11)
+
+      1.10  (2019-02-07)
+             support utf8 filenames in Windows; fix warnings and platform ifdefs
+      1.09  (2018-02-11)
+             fix typo in zlib quality API, improve STB_I_W_STATIC in C++
+      1.08  (2018-01-29)
+             add stbi__flip_vertically_on_write, external zlib, zlib quality, choose PNG filter
+      1.07  (2017-07-24)
+             doc fix
+      1.06 (2017-07-23)
+             writing JPEG (using Jon Olick's code)
+      1.05   ???
+      1.04 (2017-03-03)
+             monochrome BMP expansion
+      1.03   ???
+      1.02 (2016-04-02)
+             avoid allocating large structures on the stack
+      1.01 (2016-01-16)
+             STBIW_REALLOC_SIZED: support allocators with no realloc support
+             avoid race-condition in crc initialization
+             minor compile issues
+      1.00 (2015-09-14)
+             installable file IO function
+      0.99 (2015-09-13)
+             warning fixes; TGA rle support
+      0.98 (2015-04-08)
+             added STBIW_MALLOC, STBIW_ASSERT etc
+      0.97 (2015-01-18)
+             fixed HDR asserts, rewrote HDR rle logic
+      0.96 (2015-01-17)
+             add HDR output
+             fix monochrome BMP
+      0.95 (2014-08-17)
+             add monochrome TGA output
+      0.94 (2014-05-31)
+             rename private functions to avoid conflicts with stb_image.h
+      0.93 (2014-05-27)
+             warning fixes
+      0.92 (2010-08-01)
+             casts to unsigned char to fix warnings
+      0.91 (2010-07-17)
+             first public release
+      0.90   first internal release
+*/
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/tools/test_harness.c
+++ b/tools/test_harness.c
@@ -3,16 +3,16 @@
 
 #include "libretro.h"
 
-#include <dirent.h>
-#include <dlfcn.h>
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+
+#include <ctype.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <locale.h>
 #include <math.h>
-#ifdef __linux__
-#include <sched.h>
-#endif
+#include <signal.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -21,8 +21,19 @@
 #include <string.h>
 #include <strings.h>
 #include <time.h>
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <langinfo.h>
+#include <poll.h>
+#ifdef __linux__
+#include <sched.h>
+#endif
+#include <termios.h>
 #include <unistd.h>
 
+#include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -30,6 +41,22 @@
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
+
+#define HARNESS_TERMINAL_BUTTONS 16
+#define HARNESS_TERMINAL_HOLD_FRAMES_DEFAULT 6
+#define HARNESS_TERMINAL_FPS_DEFAULT 30.0
+
+#define HARNESS_TERMINAL_CELL_BLANK 0
+#define HARNESS_TERMINAL_CELL_BG_SPACE 1
+#define HARNESS_TERMINAL_CELL_HALF_UPPER 2
+#define HARNESS_TERMINAL_CELL_ASCII 3
+
+#define HARNESS_TERMINAL_RENDER_HALF 0
+#define HARNESS_TERMINAL_RENDER_ASCII 1
+
+#define HARNESS_TERMINAL_COLOR_MONO 0
+#define HARNESS_TERMINAL_COLOR_256 1
+#define HARNESS_TERMINAL_COLOR_TRUE 2
 
 typedef struct rom_entry_t rom_entry_t;
 struct rom_entry_t
@@ -86,6 +113,31 @@ struct screenshot_request_t
   bool     written;
 };
 
+typedef struct terminal_cell_t terminal_cell_t;
+struct terminal_cell_t
+{
+  uint8_t fg_r;
+  uint8_t fg_g;
+  uint8_t fg_b;
+  uint8_t bg_r;
+  uint8_t bg_g;
+  uint8_t bg_b;
+  uint8_t glyph;
+  uint8_t ch;
+};
+
+typedef uint32_t (*terminal_read_pixel_fn)(const void *data_,
+                                           size_t      pitch_,
+                                           unsigned    x_,
+                                           unsigned    y_);
+
+enum
+  {
+    SCREENSHOT_WHEN_NONE = 0,
+    SCREENSHOT_WHEN_NONBLANK,
+    SCREENSHOT_WHEN_CHANGED
+  };
+
 typedef struct harness_config_t harness_config_t;
 struct harness_config_t
 {
@@ -101,7 +153,13 @@ struct harness_config_t
   char *log_path;
   char *metrics_path;
   char *audio_path;
+  bool     no_audio;
   char *screenshot_path;
+  char *screenshot_every_dir;
+  uint64_t screenshot_every_step;
+  uint64_t screenshot_every_written;
+  int      screenshot_when_mode;
+  uint64_t screenshot_when_skipped;
 
   harness_option_t    *options;
   size_t               option_count;
@@ -121,9 +179,16 @@ struct harness_config_t
   bool     have_benchmark_end_frame;
   bool     have_seconds;
   bool     have_cpu;
+  bool     terminal_mode;
   bool     keep_work_dir;
   bool     user_work_dir;
   bool     verbose;
+  bool     list_bios;
+  unsigned terminal_button_hold_frames;
+  double   terminal_fps;
+  bool     terminal_fps_user;
+  int      terminal_render_override;
+  int      terminal_color_override;
 };
 
 typedef struct harness_run_t harness_run_t;
@@ -165,6 +230,12 @@ struct harness_run_t
   double core_fps;
   double sample_rate;
 
+  void   *screenshot_when_prev;
+  size_t  screenshot_when_prev_size;
+  unsigned screenshot_when_prev_width;
+  unsigned screenshot_when_prev_height;
+  enum retro_pixel_format screenshot_when_prev_fmt;
+
   uint64_t log_debug;
   uint64_t log_info;
   uint64_t log_warn;
@@ -177,6 +248,41 @@ struct harness_run_t
   bool benchmark_started;
   bool benchmark_finished;
   bool cpu_affinity_applied;
+  bool terminal_active;
+  bool terminal_quit_requested;
+  int  tty_fd;
+  int  tty_flags;
+  int  terminal_width;
+  int  terminal_height;
+  bool terminal_resize_pending;
+  int  terminal_escape;
+  uint16_t terminal_button_mask;
+  uint16_t terminal_button_mask_next;
+  uint64_t terminal_button_expire[HARNESS_TERMINAL_BUTTONS];
+  terminal_cell_t *terminal_cells;
+  terminal_cell_t *terminal_row_cells;
+  uint64_t *terminal_row_hashes;
+  unsigned terminal_cache_cols;
+  unsigned terminal_cache_rows;
+  unsigned *terminal_src_x;
+  unsigned *terminal_src_y_top;
+  unsigned *terminal_src_y_bottom;
+  unsigned terminal_map_width;
+  unsigned terminal_map_height;
+  unsigned terminal_map_cols;
+  unsigned terminal_map_rows;
+  unsigned terminal_map_render_mode;
+  int terminal_render_mode;
+  int terminal_color_mode;
+  terminal_read_pixel_fn terminal_read_pixel;
+  uint64_t terminal_last_render_frame;
+  double terminal_adaptive_fps;
+  double terminal_render_seconds_ema;
+  char *terminal_output;
+  size_t terminal_output_len;
+  size_t terminal_output_cap;
+  bool terminal_output_batching;
+  struct termios tty_orig_termios;
 };
 
 typedef struct core_api_t core_api_t;
@@ -252,6 +358,10 @@ static const char *RETROARCH_ROM_DIRS[] =
 
 static harness_config_t g_cfg;
 static harness_run_t    g_run;
+static volatile sig_atomic_t g_signal_exit_requested;
+static volatile sig_atomic_t g_signal_exit_number;
+static volatile sig_atomic_t g_signal_resize_requested;
+static bool g_terminal_force_output;
 
 RETRO_CALLCONV
 static
@@ -262,15 +372,54 @@ _harness_log(enum retro_log_level level_,
 
 static
 void
+_terminal_set_pixel_reader(enum retro_pixel_format fmt_);
+
+static
+void
+_handle_process_signal(int signo_)
+{
+  if(signo_ == SIGWINCH)
+    {
+      g_signal_resize_requested = 1;
+      return;
+    }
+
+  g_signal_exit_requested = 1;
+  if(g_signal_exit_number == 0)
+    g_signal_exit_number = signo_;
+}
+
+
+static
+void
+_install_signal_handlers(void)
+{
+  struct sigaction sa;
+
+  memset(&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = _handle_process_signal;
+
+  (void)sigaction(SIGINT, &sa, NULL);
+  (void)sigaction(SIGTERM, &sa, NULL);
+  (void)sigaction(SIGHUP, &sa, NULL);
+  (void)sigaction(SIGQUIT, &sa, NULL);
+  (void)sigaction(SIGWINCH, &sa, NULL);
+}
+
+
+static
+void
 _print_usage(FILE *f_)
 {
   fprintf(f_,
-          "Usage: test-harness --core ./opera_libretro.so [--bios /path/to/bios.bin] [options]\n"
+          "Usage: test-harness [--core ./opera_libretro.so] [--bios /path/to/bios.bin] [options]\n"
           "\n"
-          "Required:\n"
-          "  --core PATH              libretro core shared object to load\n"
+          "Core and BIOS:\n"
+          "  --core PATH              libretro core shared object to load; default\n"
+          "                           opera_libretro.so beside test-harness\n"
           "  --bios PATH              recognized 3DO BIOS ROM; default panafz1.bin\n"
-          "                           filename values search RetroArch system dirs\n"
+          "                           beside test-harness, then filename search\n"
           "\n"
           "Content and duration:\n"
           "  --title PATH             optional iso/bin/chd/cue title path\n"
@@ -281,18 +430,33 @@ _print_usage(FILE *f_)
           "  --wall-timeout S         stop after S wall seconds between frames\n"
           "  --cpu N                  pin the harness and core-created threads to CPU N\n"
           "  --input SPEC             repeatable input event, e.g. 2S=X or 120F=A\n"
+          "  --input-file PATH        file of input events (one per line; # comments)\n"
+          "  --terminal               show live terminal framebuffer and read\n"
+          "                           keyboard controls; falls back by terminal\n"
+          "                           capability\n"
+          "  --terminal-fps N         cap terminal redraw rate; 0 redraws every\n"
+          "                           video frame (default adaptive up to 30)\n"
+          "  --terminal-render MODE   terminal render mode: auto, half, ascii\n"
+          "  --terminal-color MODE    terminal color mode: auto, true, 256, mono\n"
+          "  --terminal-button-hold N  keep terminal button pressed for N frames\n"
+          "                           (default 6)\n"
           "\n"
           "Artifacts:\n"
           "  --output-dir DIR         default ./test-harness-runs/<timestamp-pid>\n"
           "  --log PATH               default <output-dir>/run.log\n"
           "  --metrics PATH           default <output-dir>/metrics.json\n"
           "  --audio PATH             write stereo s16le WAV\n"
-          "  --screenshot PATH        write final frame as PPM\n"
-          "  --screenshot-at N=PATH   write frame N as PPM, repeatable\n"
+          "  --no-audio               disable audio output capture\n"
+          "  --screenshot PATH        write final frame as PNG\n"
+          "  --screenshot-at N=PATH   write frame N as PNG, repeatable\n"
+          "  --screenshot-every N=DIR write every Nth frame as PNG into DIR\n"
+          "  --screenshot-when MODE   filter --screenshot-every output: NONBLANK or\n"
+          "                           CHANGED (skip identical-to-last-written frames)\n"
           "\n"
           "Runtime setup:\n"
           "  --font PATH              optional recognized Kanji/font ROM; filename\n"
           "                           values search the same RetroArch directories\n"
+          "  --list-bios              list recognized BIOS ROMs and exit\n"
           "  --option KEY=VALUE       repeatable core option override\n"
           "  --input supports optional holds: 2S+0.5S=A, 120F+30F=P\n"
           "  --work-dir DIR           persistent system/save staging directory\n"
@@ -559,6 +723,39 @@ _path_dirname_copy(const char *path_)
 
 static
 char *
+_executable_dir(void)
+{
+  char path[PATH_MAX];
+  ssize_t n;
+
+  n = readlink("/proc/self/exe", path, sizeof(path) - 1U);
+  if(n <= 0)
+    return NULL;
+
+  path[n] = 0;
+  return _path_dirname_copy(path);
+}
+
+
+static
+char *
+_path_in_executable_dir(const char *filename_)
+{
+  char *dir;
+  char *rv;
+
+  dir = _executable_dir();
+  if(dir == NULL)
+    return _xstrdup(filename_);
+
+  rv = _xasprintf2(dir, filename_);
+  free(dir);
+  return rv;
+}
+
+
+static
+char *
 _trim_whitespace(char *text_)
 {
   char *end;
@@ -794,6 +991,7 @@ char *
 _resolve_rom_request(const char *path_)
 {
   char *resolved;
+  char *candidate;
 
   resolved = _resolve_existing_path(path_);
   if(resolved != NULL)
@@ -802,7 +1000,51 @@ _resolve_rom_request(const char *path_)
   if(_path_has_separator(path_))
     return NULL;
 
+  candidate = _path_in_executable_dir(path_);
+  if(candidate != NULL)
+    {
+      if(_path_is_regular_file(candidate))
+        {
+          resolved = _resolve_existing_path(candidate);
+          if(resolved == NULL)
+            resolved = _xstrdup(candidate);
+          free(candidate);
+          return resolved;
+        }
+      free(candidate);
+    }
+
   return _find_rom_filename_in_retroarch_dirs(path_);
+}
+
+
+static
+void
+_print_bios_list(FILE *f_)
+{
+  size_t i;
+
+  fprintf(f_, "Recognized BIOS ROMs:\n");
+  fprintf(f_, "  %-28s %10s  %-10s  %s\n",
+          "filename", "size", "crc32", "name");
+
+  for(i = 0; BIOS_ROMS[i].filename != NULL; i++)
+    {
+      char *resolved;
+
+      fprintf(f_, "  %-28s %10" PRIu64 "  %08" PRIx32 "  %s\n",
+              BIOS_ROMS[i].filename,
+              BIOS_ROMS[i].size,
+              BIOS_ROMS[i].crc32,
+              BIOS_ROMS[i].name);
+
+      resolved = _resolve_rom_request(BIOS_ROMS[i].filename);
+      if(resolved != NULL)
+        {
+          fprintf(f_, "    found: %s\n", resolved);
+          free(resolved);
+        }
+    }
 }
 
 
@@ -1258,6 +1500,156 @@ _add_screenshot_arg(const char *arg_)
 
 static
 void
+_add_screenshot_every_arg(const char *arg_)
+{
+  char *copy;
+  char *eq;
+  uint64_t step;
+
+  copy = _xstrdup(arg_);
+  eq = strchr(copy, '=');
+  if((eq == NULL) || (eq == copy) || (eq[1] == 0))
+    {
+      fprintf(stderr, "invalid --screenshot-every, expected STEP=DIR: %s\n", arg_);
+      exit(1);
+    }
+
+  *eq = 0;
+  if((_parse_u64(copy, &step) != 0) || (step == 0))
+    {
+      fprintf(stderr, "invalid screenshot-every step: %s\n", copy);
+      exit(1);
+    }
+
+  if(_mkdir_p(eq + 1) != 0)
+    {
+      fprintf(stderr, "unable to create screenshot-every dir: %s\n", eq + 1);
+      exit(1);
+    }
+
+  g_cfg.screenshot_every_dir  = _xstrdup(eq + 1);
+  g_cfg.screenshot_every_step = step;
+  free(copy);
+}
+
+
+static
+void
+_add_screenshot_when_arg(const char *arg_)
+{
+  if(!strcasecmp(arg_, "NONBLANK"))
+    g_cfg.screenshot_when_mode = SCREENSHOT_WHEN_NONBLANK;
+  else if(!strcasecmp(arg_, "CHANGED"))
+    g_cfg.screenshot_when_mode = SCREENSHOT_WHEN_CHANGED;
+  else
+    {
+      fprintf(stderr,
+              "invalid --screenshot-when value: %s; expected NONBLANK or CHANGED\n",
+              arg_);
+      exit(1);
+    }
+}
+
+
+static
+int
+_parse_terminal_render_mode(const char *arg_)
+{
+  if(!strcasecmp(arg_, "auto"))
+    return -1;
+  if(!strcasecmp(arg_, "half") || !strcasecmp(arg_, "unicode"))
+    return HARNESS_TERMINAL_RENDER_HALF;
+  if(!strcasecmp(arg_, "ascii"))
+    return HARNESS_TERMINAL_RENDER_ASCII;
+
+  fprintf(stderr,
+          "invalid --terminal-render value: %s; expected auto, half, or ascii\n",
+          arg_);
+  exit(1);
+}
+
+
+static
+int
+_parse_terminal_color_mode(const char *arg_)
+{
+  if(!strcasecmp(arg_, "auto"))
+    return -1;
+  if(!strcasecmp(arg_, "true") || !strcasecmp(arg_, "truecolor") ||
+     !strcasecmp(arg_, "24bit"))
+    return HARNESS_TERMINAL_COLOR_TRUE;
+  if(!strcasecmp(arg_, "256") || !strcasecmp(arg_, "256color"))
+    return HARNESS_TERMINAL_COLOR_256;
+  if(!strcasecmp(arg_, "mono") || !strcasecmp(arg_, "none"))
+    return HARNESS_TERMINAL_COLOR_MONO;
+
+  fprintf(stderr,
+          "invalid --terminal-color value: %s; expected auto, true, 256, or mono\n",
+          arg_);
+  exit(1);
+}
+
+
+static
+void
+_add_inputs_from_file(const char *path_)
+{
+  FILE *f;
+  char *line;
+  size_t cap;
+  ssize_t n;
+
+  f = fopen(path_, "r");
+  if(f == NULL)
+    {
+      fprintf(stderr, "unable to open --input-file: %s: %s\n",
+              path_, strerror(errno));
+      exit(1);
+    }
+
+  line = NULL;
+  cap = 0;
+  while((n = getline(&line, &cap, f)) != -1)
+    {
+      char *s;
+      char *e;
+
+      if(n > 0 && line[n - 1] == '\n')
+        {
+          line[n - 1] = 0;
+          n--;
+        }
+      if(n > 0 && line[n - 1] == '\r')
+        {
+          line[n - 1] = 0;
+          n--;
+        }
+
+      s = line;
+      while((*s == ' ') || (*s == '\t'))
+        s++;
+
+      if((*s == 0) || (*s == '#'))
+        continue;
+
+      e = s + strlen(s);
+      while((e > s) && ((e[-1] == ' ') || (e[-1] == '\t')))
+        {
+          e--;
+          *e = 0;
+        }
+
+      if(*s != 0)
+        _add_input_from_arg(s);
+    }
+
+  free(line);
+  fclose(f);
+}
+
+
+static
+void
 _parse_args(int    argc_,
             char **argv_)
 {
@@ -1267,7 +1659,14 @@ _parse_args(int    argc_,
   g_run.saved_stdout = -1;
   g_run.saved_stderr = -1;
   g_run.log_fd       = -1;
+  g_run.tty_fd       = -1;
+  g_run.tty_flags    = -1;
   g_run.pixel_format = RETRO_PIXEL_FORMAT_0RGB1555;
+  _terminal_set_pixel_reader(g_run.pixel_format);
+  g_cfg.terminal_button_hold_frames = HARNESS_TERMINAL_HOLD_FRAMES_DEFAULT;
+  g_cfg.terminal_fps = HARNESS_TERMINAL_FPS_DEFAULT;
+  g_cfg.terminal_render_override = -1;
+  g_cfg.terminal_color_override = -1;
 
   for(i = 1; i < argc_; i++)
     {
@@ -1298,7 +1697,45 @@ _parse_args(int    argc_,
       else if(strcmp(arg, "--metrics") == 0)
         g_cfg.metrics_path = _xstrdup(argv_[++i]);
       else if(strcmp(arg, "--audio") == 0)
-        g_cfg.audio_path = _xstrdup(argv_[++i]);
+        {
+          free(g_cfg.audio_path);
+          g_cfg.audio_path = _xstrdup(argv_[++i]);
+          g_cfg.no_audio = false;
+        }
+      else if(strcmp(arg, "--terminal") == 0)
+        g_cfg.terminal_mode = true;
+      else if(strcmp(arg, "--terminal-fps") == 0)
+        {
+          if((_parse_double_value(argv_[++i], &g_cfg.terminal_fps) != 0) ||
+             !isfinite(g_cfg.terminal_fps) || (g_cfg.terminal_fps < 0.0))
+            {
+              fprintf(stderr, "--terminal-fps must be a non-negative number\n");
+              exit(1);
+            }
+          g_cfg.terminal_fps_user = true;
+        }
+      else if(strcmp(arg, "--terminal-render") == 0)
+        g_cfg.terminal_render_override = _parse_terminal_render_mode(argv_[++i]);
+      else if(strcmp(arg, "--terminal-color") == 0)
+        g_cfg.terminal_color_override = _parse_terminal_color_mode(argv_[++i]);
+      else if(strcmp(arg, "--terminal-button-hold") == 0)
+        {
+          uint64_t hold_frames;
+
+          if(_parse_u64(argv_[++i], &hold_frames) != 0)
+            {
+              fprintf(stderr, "invalid --terminal-button-hold value\n");
+              exit(1);
+            }
+
+          if((hold_frames == 0) || (hold_frames > UINT_MAX))
+            {
+              fprintf(stderr, "--terminal-button-hold must be between 1 and %u\n", UINT_MAX);
+              exit(1);
+            }
+
+          g_cfg.terminal_button_hold_frames = (unsigned)hold_frames;
+        }
       else if(strcmp(arg, "--screenshot") == 0)
         g_cfg.screenshot_path = _xstrdup(argv_[++i]);
       else if(strcmp(arg, "--frames") == 0)
@@ -1360,12 +1797,26 @@ _parse_args(int    argc_,
         _add_option_from_arg(argv_[++i]);
       else if(strcmp(arg, "--input") == 0)
         _add_input_from_arg(argv_[++i]);
+      else if(strcmp(arg, "--input-file") == 0)
+        _add_inputs_from_file(argv_[++i]);
       else if(strcmp(arg, "--screenshot-at") == 0)
         _add_screenshot_arg(argv_[++i]);
+      else if(strcmp(arg, "--screenshot-every") == 0)
+        _add_screenshot_every_arg(argv_[++i]);
+      else if(strcmp(arg, "--screenshot-when") == 0)
+        _add_screenshot_when_arg(argv_[++i]);
       else if(strcmp(arg, "--keep-work-dir") == 0)
         g_cfg.keep_work_dir = true;
+      else if(strcmp(arg, "--no-audio") == 0)
+        {
+          g_cfg.no_audio = true;
+          free(g_cfg.audio_path);
+          g_cfg.audio_path = NULL;
+        }
       else if(strcmp(arg, "--verbose") == 0)
         g_cfg.verbose = true;
+      else if(strcmp(arg, "--list-bios") == 0)
+        g_cfg.list_bios = true;
       else
         {
           fprintf(stderr, "unknown argument: %s\n", arg);
@@ -1403,9 +1854,16 @@ _validate_arg_followers(int    argc_,
         !strcmp(arg, "--seconds") ||
         !strcmp(arg, "--wall-timeout") ||
         !strcmp(arg, "--cpu") ||
+        !strcmp(arg, "--terminal-fps") ||
+        !strcmp(arg, "--terminal-render") ||
+        !strcmp(arg, "--terminal-color") ||
+        !strcmp(arg, "--terminal-button-hold") ||
         !strcmp(arg, "--option") ||
         !strcmp(arg, "--input") ||
-        !strcmp(arg, "--screenshot-at");
+        !strcmp(arg, "--input-file") ||
+        !strcmp(arg, "--screenshot-at") ||
+        !strcmp(arg, "--screenshot-every") ||
+        !strcmp(arg, "--screenshot-when");
 
       if(needs_value)
         {
@@ -1451,13 +1909,20 @@ _prepare_paths(void)
   char *resolved;
 
   if(g_cfg.core_path == NULL)
-    {
-      fprintf(stderr, "--core is required\n");
-      exit(1);
-    }
+    g_cfg.core_path = _path_in_executable_dir("opera_libretro.so");
 
   if(g_cfg.bios_path == NULL)
-    g_cfg.bios_path = _xstrdup("panafz1.bin");
+    {
+      char *default_bios = _path_in_executable_dir("panafz1.bin");
+
+      if((default_bios != NULL) && _path_is_regular_file(default_bios))
+        g_cfg.bios_path = default_bios;
+      else
+        {
+          free(default_bios);
+          g_cfg.bios_path = _xstrdup("panafz1.bin");
+        }
+    }
 
   resolved = _resolve_existing_path(g_cfg.core_path);
   if(resolved == NULL)
@@ -1475,7 +1940,9 @@ _prepare_paths(void)
         fprintf(stderr, "unable to resolve BIOS path: %s\n", g_cfg.bios_path);
       else
         fprintf(stderr,
-                "unable to find BIOS file %s in the current directory or common RetroArch system directories\n",
+                "unable to find BIOS file %s beside test-harness, "
+                "in the current directory, or common RetroArch "
+                "system directories\n",
                 g_cfg.bios_path);
       exit(1);
     }
@@ -1491,7 +1958,8 @@ _prepare_paths(void)
             fprintf(stderr, "unable to resolve font path: %s\n", g_cfg.font_path);
           else
             fprintf(stderr,
-                    "unable to find font file %s in the current directory or common RetroArch system directories\n",
+                    "unable to find font file %s in the current directory "
+                    "or common RetroArch system directories\n",
                     g_cfg.font_path);
           exit(1);
         }
@@ -1788,10 +2256,14 @@ _stage_rom(const char        *source_path_,
   if((by_base != NULL) && (by_hash != by_base))
     {
       if(by_hash != NULL)
-        _report_error("%s ROM basename matched %s but content matched %s; use a filename that matches the ROM content\n",
+        _report_error("%s ROM basename matched %s but content matched %s; "
+                      "use a filename that matches the ROM content\n",
                       kind_, by_base->filename, by_hash->filename);
       else
-        _report_error("%s ROM basename matched %s but content did not match the known size/crc32 (got size=%" PRIu64 " crc32=%08" PRIx32 ", expected size=%" PRIu64 " crc32=%08" PRIx32 ")\n",
+        _report_error("%s ROM basename matched %s but content did not match "
+                      "the known size/crc32 (got size=%" PRIu64 " "
+                      "crc32=%08" PRIx32 ", expected size=%" PRIu64 " "
+                      "crc32=%08" PRIx32 ")\n",
                       kind_, by_base->filename, size, crc, by_base->size, by_base->crc32);
       return -1;
     }
@@ -2023,6 +2495,7 @@ _log_level_name(enum retro_log_level level_)
   return "unknown";
 }
 
+
 RETRO_CALLCONV
 static
 void
@@ -2059,6 +2532,7 @@ _harness_log(enum retro_log_level level_,
   va_end(ap);
   fflush(g_run.log_file);
 }
+
 
 RETRO_CALLCONV
 static
@@ -2111,10 +2585,18 @@ _harness_environment(unsigned cmd_,
       *(bool *)data_ = false;
       return true;
     case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
-      g_run.pixel_format = *(const enum retro_pixel_format *)data_;
-      return ((g_run.pixel_format == RETRO_PIXEL_FORMAT_0RGB1555) ||
-              (g_run.pixel_format == RETRO_PIXEL_FORMAT_XRGB8888) ||
-              (g_run.pixel_format == RETRO_PIXEL_FORMAT_RGB565));
+      {
+        enum retro_pixel_format fmt = *(const enum retro_pixel_format *)data_;
+
+        if((fmt != RETRO_PIXEL_FORMAT_0RGB1555) &&
+           (fmt != RETRO_PIXEL_FORMAT_XRGB8888) &&
+           (fmt != RETRO_PIXEL_FORMAT_RGB565))
+          return false;
+
+        g_run.pixel_format = fmt;
+        _terminal_set_pixel_reader(fmt);
+        return true;
+      }
     case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
       g_run.av_info = *(const struct retro_system_av_info *)data_;
       return true;
@@ -2149,6 +2631,74 @@ _scale_6_to_8(uint32_t v_)
 
 
 static
+uint32_t
+_terminal_read_pixel_0rgb1555(const void *data_,
+                              size_t      pitch_,
+                              unsigned    x_,
+                              unsigned    y_)
+{
+  const uint8_t *row = (const uint8_t *)data_ + (pitch_ * y_);
+  uint16_t p = ((const uint16_t *)row)[x_];
+  uint32_t r = _scale_5_to_8((p >> 10) & 0x1f);
+  uint32_t g = _scale_5_to_8((p >> 5) & 0x1f);
+  uint32_t b = _scale_5_to_8(p & 0x1f);
+
+  return (r << 16U) | (g << 8U) | b;
+}
+
+
+static
+uint32_t
+_terminal_read_pixel_xrgb8888(const void *data_,
+                              size_t      pitch_,
+                              unsigned    x_,
+                              unsigned    y_)
+{
+  const uint8_t *row = (const uint8_t *)data_ + (pitch_ * y_);
+  uint32_t p = ((const uint32_t *)row)[x_];
+
+  return p & 0x00ffffffU;
+}
+
+
+static
+uint32_t
+_terminal_read_pixel_rgb565(const void *data_,
+                            size_t      pitch_,
+                            unsigned    x_,
+                            unsigned    y_)
+{
+  const uint8_t *row = (const uint8_t *)data_ + (pitch_ * y_);
+  uint16_t p = ((const uint16_t *)row)[x_];
+  uint32_t r = _scale_5_to_8((p >> 11) & 0x1f);
+  uint32_t g = _scale_6_to_8((p >> 5) & 0x3f);
+  uint32_t b = _scale_5_to_8(p & 0x1f);
+
+  return (r << 16U) | (g << 8U) | b;
+}
+
+
+static
+void
+_terminal_set_pixel_reader(enum retro_pixel_format fmt_)
+{
+  switch(fmt_)
+    {
+    case RETRO_PIXEL_FORMAT_XRGB8888:
+      g_run.terminal_read_pixel = _terminal_read_pixel_xrgb8888;
+      break;
+    case RETRO_PIXEL_FORMAT_RGB565:
+      g_run.terminal_read_pixel = _terminal_read_pixel_rgb565;
+      break;
+    case RETRO_PIXEL_FORMAT_0RGB1555:
+    default:
+      g_run.terminal_read_pixel = _terminal_read_pixel_0rgb1555;
+      break;
+    }
+}
+
+
+static
 const
 char *
 _pixel_format_name(enum retro_pixel_format fmt_)
@@ -2171,14 +2721,15 @@ _pixel_format_name(enum retro_pixel_format fmt_)
 
 static
 int
-_write_ppm(const char             *path_,
+_write_png(const char             *path_,
            const void             *data_,
            unsigned                width_,
            unsigned                height_,
            size_t                  pitch_,
            enum retro_pixel_format fmt_)
 {
-  FILE *f;
+  uint8_t *packed;
+  size_t   stride;
   unsigned y;
 
   if((data_ == NULL) || (width_ == 0) || (height_ == 0))
@@ -2187,52 +2738,58 @@ _write_ppm(const char             *path_,
   if(_mkdir_parent(path_) != 0)
     return -1;
 
-  f = fopen(path_, "wb");
-  if(f == NULL)
+  if(width_ > (UINT_MAX / 3))
+    return -1;
+  stride = (size_t)width_ * 3;
+
+  if((stride > 0) && (height_ > (SIZE_MAX / stride)))
     return -1;
 
-  fprintf(f, "P6\n%u %u\n255\n", width_, height_);
+  packed = (uint8_t *)malloc(stride * height_);
+  if(packed == NULL)
+    return -1;
 
   for(y = 0; y < height_; y++)
     {
       const uint8_t *row = (const uint8_t *)data_ + (pitch_ * y);
+      uint8_t       *out = packed + (stride * y);
       unsigned x;
 
       for(x = 0; x < width_; x++)
         {
-          uint8_t rgb[3];
-
           if(fmt_ == RETRO_PIXEL_FORMAT_XRGB8888)
             {
               uint32_t p = ((const uint32_t *)row)[x];
-              rgb[0] = (uint8_t)((p >> 16) & 0xff);
-              rgb[1] = (uint8_t)((p >> 8)  & 0xff);
-              rgb[2] = (uint8_t)(p & 0xff);
+              out[x * 3 + 0] = (uint8_t)((p >> 16) & 0xff);
+              out[x * 3 + 1] = (uint8_t)((p >> 8)  & 0xff);
+              out[x * 3 + 2] = (uint8_t)(p & 0xff);
             }
           else if(fmt_ == RETRO_PIXEL_FORMAT_RGB565)
             {
               uint16_t p = ((const uint16_t *)row)[x];
-              rgb[0] = _scale_5_to_8((p >> 11) & 0x1f);
-              rgb[1] = _scale_6_to_8((p >> 5)  & 0x3f);
-              rgb[2] = _scale_5_to_8(p & 0x1f);
+              out[x * 3 + 0] = _scale_5_to_8((p >> 11) & 0x1f);
+              out[x * 3 + 1] = _scale_6_to_8((p >> 5)  & 0x3f);
+              out[x * 3 + 2] = _scale_5_to_8(p & 0x1f);
             }
           else
             {
               uint16_t p = ((const uint16_t *)row)[x];
-              rgb[0] = _scale_5_to_8((p >> 10) & 0x1f);
-              rgb[1] = _scale_5_to_8((p >> 5)  & 0x1f);
-              rgb[2] = _scale_5_to_8(p & 0x1f);
-            }
-
-          if(fwrite(rgb, 1, sizeof(rgb), f) != sizeof(rgb))
-            {
-              fclose(f);
-              return -1;
+              out[x * 3 + 0] = _scale_5_to_8((p >> 10) & 0x1f);
+              out[x * 3 + 1] = _scale_5_to_8((p >> 5)  & 0x1f);
+              out[x * 3 + 2] = _scale_5_to_8(p & 0x1f);
             }
         }
     }
 
-  return (fclose(f) == 0) ? 0 : -1;
+  if(stbi_write_png(path_, (int)width_, (int)height_, 3,
+                    packed, (int)stride) == 0)
+    {
+      free(packed);
+      return -1;
+    }
+
+  free(packed);
+  return 0;
 }
 
 
@@ -2250,6 +2807,131 @@ _frame_copy_size(unsigned  height_,
 
   *size_out_ = pitch_ * (size_t)height_;
   return true;
+}
+
+
+static
+unsigned
+_pixel_size(enum retro_pixel_format fmt_)
+{
+  switch(fmt_)
+    {
+    case RETRO_PIXEL_FORMAT_XRGB8888: return 4;
+    case RETRO_PIXEL_FORMAT_RGB565:
+    case RETRO_PIXEL_FORMAT_0RGB1555: return 2;
+    default:                          return 0;
+    }
+}
+
+
+static
+bool
+_frame_is_blank(const void             *data_,
+                unsigned                width_,
+                unsigned                height_,
+                size_t                  pitch_,
+                enum retro_pixel_format fmt_)
+{
+  unsigned psize;
+  const uint8_t *row;
+  unsigned y;
+
+  psize = _pixel_size(fmt_);
+  if((psize == 0) || (data_ == NULL) || (width_ == 0))
+    return false;
+
+  row = (const uint8_t *)data_;
+  for(y = 0; y < height_; y++)
+    {
+      size_t row_bytes = (size_t)width_ * psize;
+      size_t i;
+      for(i = 0; i < row_bytes; i++)
+        if(row[i] != 0)
+          return false;
+      row += pitch_;
+    }
+  return true;
+}
+
+
+static
+bool
+_frame_equals_prev(const void             *data_,
+                   unsigned                width_,
+                   unsigned                height_,
+                   size_t                  pitch_,
+                   enum retro_pixel_format fmt_)
+{
+  unsigned psize;
+  const uint8_t *row;
+  const uint8_t *prow;
+  unsigned y;
+
+  psize = _pixel_size(fmt_);
+  if((psize == 0) || (data_ == NULL) || (g_run.screenshot_when_prev == NULL))
+    return false;
+
+  if((g_run.screenshot_when_prev_width  != width_)  ||
+     (g_run.screenshot_when_prev_height != height_) ||
+     (g_run.screenshot_when_prev_fmt    != fmt_))
+    return false;
+
+  row  = (const uint8_t *)data_;
+  prow = (const uint8_t *)g_run.screenshot_when_prev;
+  for(y = 0; y < height_; y++)
+    {
+      if(memcmp(row, prow, (size_t)width_ * psize) != 0)
+        return false;
+      row  += pitch_;
+      prow += (size_t)width_ * psize;
+    }
+  return true;
+}
+
+
+static
+void
+_store_screenshot_when_prev(const void             *data_,
+                            unsigned                width_,
+                            unsigned                height_,
+                            size_t                  pitch_,
+                            enum retro_pixel_format fmt_)
+{
+  unsigned psize;
+  size_t row_bytes;
+  size_t total;
+  const uint8_t *row;
+  uint8_t *dst;
+  void *next;
+  unsigned y;
+
+  psize = _pixel_size(fmt_);
+  if((psize == 0) || (data_ == NULL) || (width_ == 0))
+    return;
+
+  row_bytes = (size_t)width_ * psize;
+  total     = row_bytes * height_;
+  if(total > g_run.screenshot_when_prev_size)
+    {
+      next = realloc(g_run.screenshot_when_prev, total);
+      if(next == NULL)
+        return;
+      g_run.screenshot_when_prev      = next;
+      g_run.screenshot_when_prev_size = total;
+    }
+
+  row = (const uint8_t *)data_;
+  dst = (uint8_t *)g_run.screenshot_when_prev;
+  for(y = 0; y < height_; y++)
+    {
+      memcpy(dst, row, row_bytes);
+      row += pitch_;
+      dst += row_bytes;
+    }
+
+  g_run.screenshot_when_prev_width  = width_;
+  g_run.screenshot_when_prev_height = height_;
+  g_run.screenshot_when_prev_fmt    = fmt_;
 }
 
 
@@ -2320,6 +3002,286 @@ _store_last_frame(const void             *data_,
   g_run.last_pixel_format = fmt_;
 }
 
+
+static
+void
+_terminal_render_frame(const void             *data_,
+                       unsigned                width_,
+                       unsigned                height_,
+                       size_t                  pitch_,
+                       enum retro_pixel_format  fmt_);
+
+static
+bool
+_terminal_should_render(void);
+
+static
+void
+_terminal_move_cursor(unsigned row_,
+                      unsigned col_);
+
+static
+unsigned
+_terminal_u64_ceil_div(uint64_t value_,
+                       uint64_t divisor_);
+
+static
+void
+_terminal_write_all(const void *data_,
+                    size_t       size_);
+
+static
+void
+_terminal_write_spaces(size_t count_)
+{
+  static const char spaces[] = "                                                                ";
+  size_t len = sizeof(spaces) - 1;
+
+  while(count_ > 0)
+    {
+      size_t chunk = (count_ < len) ? count_ : len;
+      _terminal_write_all(spaces, chunk);
+      count_ -= chunk;
+    }
+}
+
+
+static
+void
+_terminal_write_repeat_char(char     ch_,
+                            unsigned count_)
+{
+  char buf[128];
+
+  memset(buf, ch_, sizeof(buf));
+  while(count_ > 0U)
+    {
+      size_t chunk = (count_ < sizeof(buf)) ? (size_t)count_ : sizeof(buf);
+      _terminal_write_all(buf, chunk);
+      count_ -= (unsigned)chunk;
+    }
+}
+
+
+static
+void
+_terminal_write_repeat_utf8(const char *utf8_,
+                            size_t      len_,
+                            unsigned    count_)
+{
+  char buf[192];
+  unsigned per_chunk;
+
+  if((utf8_ == NULL) || (len_ == 0U) || (len_ > sizeof(buf)))
+    return;
+
+  per_chunk = (unsigned)(sizeof(buf) / len_);
+  if(per_chunk == 0U)
+    per_chunk = 1U;
+
+  while(count_ > 0U)
+    {
+      unsigned reps = (count_ < per_chunk) ? count_ : per_chunk;
+      unsigned i;
+
+      for(i = 0; i < reps; i++)
+        memcpy(buf + ((size_t)i * len_), utf8_, len_);
+
+      _terminal_write_all(buf, (size_t)reps * len_);
+      count_ -= reps;
+    }
+}
+
+
+static
+bool
+_ascii_contains_case(const char *haystack_,
+                     const char *needle_)
+{
+  size_t needle_len;
+
+  if((haystack_ == NULL) || (needle_ == NULL))
+    return false;
+
+  needle_len = strlen(needle_);
+  if(needle_len == 0)
+    return true;
+
+  for(; *haystack_ != 0; haystack_++)
+    {
+      size_t i;
+
+      for(i = 0; i < needle_len; i++)
+        {
+          unsigned char a = (unsigned char)haystack_[i];
+          unsigned char b = (unsigned char)needle_[i];
+
+          if(a == 0)
+            return false;
+          if(tolower(a) != tolower(b))
+            break;
+        }
+
+      if(i == needle_len)
+        return true;
+    }
+
+  return false;
+}
+
+
+static
+void
+_terminal_detect_capabilities(void)
+{
+  const char *codeset;
+  const char *term;
+  const char *colorterm;
+  bool utf8;
+  bool truecolor;
+  bool color256;
+
+  (void)setlocale(LC_CTYPE, "");
+
+  codeset = nl_langinfo(CODESET);
+  term = getenv("TERM");
+  colorterm = getenv("COLORTERM");
+
+  utf8 = _ascii_contains_case(codeset, "UTF-8") ||
+    _ascii_contains_case(codeset, "UTF8") ||
+    _ascii_contains_case(getenv("LC_ALL"), "UTF-8") ||
+    _ascii_contains_case(getenv("LC_CTYPE"), "UTF-8") ||
+    _ascii_contains_case(getenv("LANG"), "UTF-8");
+
+  truecolor = _ascii_contains_case(colorterm, "truecolor") ||
+    _ascii_contains_case(colorterm, "24bit") ||
+    _ascii_contains_case(term, "-direct") ||
+    _ascii_contains_case(term, "truecolor");
+  color256 = truecolor || _ascii_contains_case(term, "256color");
+
+  if((getenv("NO_COLOR") != NULL) || (term == NULL) || (strcmp(term, "dumb") == 0))
+    {
+      truecolor = false;
+      color256 = false;
+    }
+
+  if(g_cfg.terminal_color_override >= 0)
+    g_run.terminal_color_mode = g_cfg.terminal_color_override;
+  else if(truecolor)
+    g_run.terminal_color_mode = HARNESS_TERMINAL_COLOR_TRUE;
+  else if(color256)
+    g_run.terminal_color_mode = HARNESS_TERMINAL_COLOR_256;
+  else
+    g_run.terminal_color_mode = HARNESS_TERMINAL_COLOR_MONO;
+
+  if(g_cfg.terminal_render_override >= 0)
+    g_run.terminal_render_mode = g_cfg.terminal_render_override;
+  else if(utf8 && (g_run.terminal_color_mode != HARNESS_TERMINAL_COLOR_MONO))
+    g_run.terminal_render_mode = HARNESS_TERMINAL_RENDER_HALF;
+  else
+    g_run.terminal_render_mode = HARNESS_TERMINAL_RENDER_ASCII;
+}
+
+
+static
+bool
+_terminal_adaptive_enabled(void)
+{
+  return g_cfg.terminal_mode && !g_cfg.terminal_fps_user &&
+    (g_cfg.terminal_fps > 0.0) && (g_run.core_fps > 0.0);
+}
+
+
+static
+double
+_terminal_effective_fps(void)
+{
+  if(_terminal_adaptive_enabled() && (g_run.terminal_adaptive_fps > 0.0))
+    return g_run.terminal_adaptive_fps;
+
+  return g_cfg.terminal_fps;
+}
+
+
+static
+void
+_terminal_update_adaptive_fps(double render_seconds_)
+{
+  double fps;
+  double target_fps;
+  double max_fps;
+  double min_fps = 5.0;
+
+  if(!_terminal_adaptive_enabled() || (render_seconds_ <= 0.0) ||
+     !isfinite(render_seconds_))
+    return;
+
+  if(g_run.terminal_render_seconds_ema <= 0.0)
+    g_run.terminal_render_seconds_ema = render_seconds_;
+  else
+    g_run.terminal_render_seconds_ema =
+      (g_run.terminal_render_seconds_ema * 0.85) + (render_seconds_ * 0.15);
+
+  fps = _terminal_effective_fps();
+  max_fps = g_cfg.terminal_fps;
+  if(max_fps > g_run.core_fps)
+    max_fps = g_run.core_fps;
+  if(max_fps < min_fps)
+    min_fps = max_fps;
+
+  if(g_run.terminal_render_seconds_ema > (0.70 / fps))
+    {
+      target_fps = 0.70 / g_run.terminal_render_seconds_ema;
+      if(target_fps < min_fps)
+        target_fps = min_fps;
+      if(target_fps < fps)
+        g_run.terminal_adaptive_fps = target_fps;
+    }
+  else if((fps < max_fps) &&
+          (g_run.terminal_render_seconds_ema < (0.25 / fps)))
+    {
+      fps += 1.0;
+      if(fps > max_fps)
+        fps = max_fps;
+      g_run.terminal_adaptive_fps = fps;
+    }
+}
+
+
+static
+bool
+_terminal_should_render(void)
+{
+  double step_d;
+  uint64_t step;
+  double fps;
+
+  if(!g_cfg.terminal_mode)
+    return false;
+
+  if(g_run.terminal_last_render_frame == 0)
+    return true;
+
+  fps = _terminal_effective_fps();
+
+  if((fps <= 0.0) || (g_run.core_fps <= 0.0))
+    return true;
+
+  if(fps >= g_run.core_fps)
+    return true;
+
+  step_d = ceil(g_run.core_fps / fps);
+  if(!isfinite(step_d) || (step_d <= 1.0))
+    return true;
+  if(step_d >= (double)UINT64_MAX)
+    step = UINT64_MAX;
+  else
+    step = (uint64_t)step_d;
+
+  return (g_run.current_frame - g_run.terminal_last_render_frame) >= step;
+}
+
+
 RETRO_CALLCONV
 static
 void
@@ -2347,6 +3309,57 @@ _harness_video_refresh(const void *data_,
                        shot->path);
           g_run.artifact_error = true;
         }
+    }
+
+  if((g_cfg.screenshot_every_step > 0) && (data_ != NULL) &&
+     (g_run.current_frame > 0) &&
+     ((g_run.current_frame % g_cfg.screenshot_every_step) == 0))
+    {
+      bool write_it = true;
+
+      if(g_cfg.screenshot_when_mode == SCREENSHOT_WHEN_NONBLANK)
+        write_it = !_frame_is_blank(data_, width_, height_,
+                                    pitch_, g_run.pixel_format);
+      else if(g_cfg.screenshot_when_mode == SCREENSHOT_WHEN_CHANGED)
+        write_it = !_frame_equals_prev(data_, width_, height_,
+                                       pitch_, g_run.pixel_format);
+
+      if(write_it)
+        {
+          char path[PATH_MAX];
+          int n;
+
+          n = snprintf(path, sizeof(path), "%s/frame%06" PRIu64 ".png",
+                       g_cfg.screenshot_every_dir, g_run.current_frame);
+          if((n > 0) && ((size_t)n < sizeof(path)))
+            {
+              if(_write_png(path, data_, width_, height_, pitch_,
+                            g_run.pixel_format) != 0)
+                {
+                  _harness_log(RETRO_LOG_ERROR,
+                               "[Harness]: failed writing periodic screenshot %s\n",
+                               path);
+                  g_run.artifact_error = true;
+                }
+              else
+                {
+                  g_cfg.screenshot_every_written++;
+                  if(g_cfg.screenshot_when_mode == SCREENSHOT_WHEN_CHANGED)
+                    _store_screenshot_when_prev(data_, width_, height_,
+                                                pitch_, g_run.pixel_format);
+                }
+            }
+        }
+      else
+        g_cfg.screenshot_when_skipped++;
+    }
+
+  if(_terminal_should_render())
+    {
+      double render_start = _monotonic_seconds();
+      _terminal_render_frame(data_, width_, height_, pitch_, g_run.pixel_format);
+      g_run.terminal_last_render_frame = g_run.current_frame;
+      _terminal_update_adaptive_fps(_monotonic_seconds() - render_start);
     }
 }
 
@@ -2412,7 +3425,7 @@ _open_audio(void)
 {
   uint32_t sample_rate;
 
-  if(g_cfg.audio_path == NULL)
+  if(g_cfg.no_audio || (g_cfg.audio_path == NULL))
     return 0;
 
   if(_mkdir_parent(g_cfg.audio_path) != 0)
@@ -2448,6 +3461,7 @@ _close_audio(void)
   g_run.audio_file = NULL;
 }
 
+
 RETRO_CALLCONV
 static
 void
@@ -2468,6 +3482,7 @@ _harness_audio_sample(int16_t left_,
   else
     g_run.audio_bytes += sizeof(frame);
 }
+
 
 RETRO_CALLCONV
 static
@@ -2491,12 +3506,1328 @@ _harness_audio_sample_batch(const int16_t *data_,
   return frames_;
 }
 
+
+static
+void
+_sleep_for_seconds(double seconds_)
+{
+  struct timespec req;
+  struct timespec rem;
+
+  if(seconds_ <= 0.0)
+    return;
+
+  req.tv_sec = (time_t)seconds_;
+  req.tv_nsec = (long)((seconds_ - (double)req.tv_sec) * 1000000000.0);
+
+  while(!g_signal_exit_requested &&
+        (nanosleep(&req, &rem) != 0) && (errno == EINTR))
+    req = rem;
+}
+
+
+static
+unsigned
+_terminal_u64_ceil_div(uint64_t value_,
+                       uint64_t divisor_)
+{
+  if(divisor_ == 0ULL)
+    return 0;
+
+  if(value_ > (UINT64_MAX - (divisor_ - 1ULL)))
+    return 0;
+
+  return (unsigned)((value_ + divisor_ - 1ULL) / divisor_);
+}
+
+
+static
+char *
+_terminal_append_uint(char    *out_,
+                      unsigned value_)
+{
+  char tmp[10];
+  unsigned n = 0;
+
+  if(value_ == 0U)
+    {
+      *out_++ = '0';
+      return out_;
+    }
+
+  while(value_ > 0U)
+    {
+      tmp[n++] = (char)('0' + (value_ % 10U));
+      value_ /= 10U;
+    }
+
+  while(n > 0U)
+    *out_++ = tmp[--n];
+
+  return out_;
+}
+
+
+static
+char *
+_terminal_append_literal(char       *out_,
+                         const char *literal_)
+{
+  while(*literal_ != 0)
+    *out_++ = *literal_++;
+
+  return out_;
+}
+
+
+static
+uint8_t
+_terminal_rgb_to_256(uint32_t rgb_)
+{
+  unsigned r = (rgb_ >> 16U) & 0xffU;
+  unsigned g = (rgb_ >> 8U) & 0xffU;
+  unsigned b = rgb_ & 0xffU;
+  unsigned gray;
+  unsigned cr;
+  unsigned cg;
+  unsigned cb;
+  unsigned cube_r;
+  unsigned cube_g;
+  unsigned cube_b;
+  unsigned gray_v;
+  unsigned cube_diff;
+  unsigned gray_diff;
+
+  cr = (r * 5U + 127U) / 255U;
+  cg = (g * 5U + 127U) / 255U;
+  cb = (b * 5U + 127U) / 255U;
+  cube_r = (cr == 0U) ? 0U : (55U + (cr * 40U));
+  cube_g = (cg == 0U) ? 0U : (55U + (cg * 40U));
+  cube_b = (cb == 0U) ? 0U : (55U + (cb * 40U));
+  cube_diff = (r > cube_r ? r - cube_r : cube_r - r) +
+    (g > cube_g ? g - cube_g : cube_g - g) +
+    (b > cube_b ? b - cube_b : cube_b - b);
+
+  gray = (r * 299U + g * 587U + b * 114U) / 1000U;
+  gray_v = (gray <= 8U) ? 0U : ((gray >= 238U) ? 255U :
+                                (8U + (((gray - 8U + 5U) / 10U) * 10U)));
+  gray_diff = (r > gray_v ? r - gray_v : gray_v - r) +
+    (g > gray_v ? g - gray_v : gray_v - g) +
+    (b > gray_v ? b - gray_v : gray_v - b);
+
+  if(gray_diff < cube_diff)
+    {
+      unsigned idx = (gray <= 8U) ? 16U : ((gray >= 238U) ? 231U :
+                                           (232U + ((gray - 8U + 5U) / 10U)));
+      if(idx > 255U)
+        idx = 255U;
+      return (uint8_t)idx;
+    }
+
+  return (uint8_t)(16U + (36U * cr) + (6U * cg) + cb);
+}
+
+
+static
+void
+_terminal_store_color(uint32_t  rgb_,
+                      uint8_t  *r_,
+                      uint8_t  *g_,
+                      uint8_t  *b_)
+{
+  if(g_run.terminal_color_mode == HARNESS_TERMINAL_COLOR_TRUE)
+    {
+      *r_ = (uint8_t)((rgb_ >> 16U) & 0xffU);
+      *g_ = (uint8_t)((rgb_ >> 8U) & 0xffU);
+      *b_ = (uint8_t)(rgb_ & 0xffU);
+    }
+  else if(g_run.terminal_color_mode == HARNESS_TERMINAL_COLOR_256)
+    {
+      *r_ = _terminal_rgb_to_256(rgb_);
+      *g_ = 0;
+      *b_ = 0;
+    }
+  else
+    {
+      *r_ = 0;
+      *g_ = 0;
+      *b_ = 0;
+    }
+}
+
+
+static
+void
+_terminal_move_cursor(unsigned row_,
+                      unsigned col_)
+{
+  char seq[32];
+  char *p = seq;
+
+  if(row_ == 0U)
+    row_ = 1U;
+
+  if(col_ == 0U)
+    col_ = 1U;
+
+  *p++ = '\x1b';
+  *p++ = '[';
+  p = _terminal_append_uint(p, row_);
+  *p++ = ';';
+  p = _terminal_append_uint(p, col_);
+  *p++ = 'H';
+
+  _terminal_write_all(seq, (size_t)(p - seq));
+}
+
+
+static
+void
+_terminal_write_sgr_rgb(bool    set_fg_,
+                        uint8_t fg_r_,
+                        uint8_t fg_g_,
+                        uint8_t fg_b_,
+                        bool    set_bg_,
+                        uint8_t bg_r_,
+                        uint8_t bg_g_,
+                        uint8_t bg_b_)
+{
+  char seq[64];
+  char *p = seq;
+
+  if(!set_fg_ && !set_bg_)
+    return;
+
+  if(g_run.terminal_color_mode == HARNESS_TERMINAL_COLOR_MONO)
+    return;
+
+  *p++ = '\x1b';
+  *p++ = '[';
+
+  if(set_fg_)
+    {
+      if(g_run.terminal_color_mode == HARNESS_TERMINAL_COLOR_256)
+        {
+          p = _terminal_append_literal(p, "38;5;");
+          p = _terminal_append_uint(p, fg_r_);
+        }
+      else
+        {
+          p = _terminal_append_literal(p, "38;2;");
+          p = _terminal_append_uint(p, fg_r_);
+          *p++ = ';';
+          p = _terminal_append_uint(p, fg_g_);
+          *p++ = ';';
+          p = _terminal_append_uint(p, fg_b_);
+        }
+    }
+
+  if(set_bg_)
+    {
+      if(set_fg_)
+        *p++ = ';';
+      if(g_run.terminal_color_mode == HARNESS_TERMINAL_COLOR_256)
+        {
+          p = _terminal_append_literal(p, "48;5;");
+          p = _terminal_append_uint(p, bg_r_);
+        }
+      else
+        {
+          p = _terminal_append_literal(p, "48;2;");
+          p = _terminal_append_uint(p, bg_r_);
+          *p++ = ';';
+          p = _terminal_append_uint(p, bg_g_);
+          *p++ = ';';
+          p = _terminal_append_uint(p, bg_b_);
+        }
+    }
+
+  *p++ = 'm';
+  _terminal_write_all(seq, (size_t)(p - seq));
+}
+
+
+static
+void
+_terminal_write_direct(const void *data_,
+                       size_t      size_)
+{
+  while((g_terminal_force_output || !g_signal_exit_requested) &&
+        (data_ != NULL) && (size_ > 0))
+    {
+      ssize_t n;
+
+      n = write(g_run.tty_fd, data_, size_);
+      if(n < 0)
+        {
+          if(errno == EINTR)
+            {
+              if(g_signal_exit_requested && !g_terminal_force_output)
+                return;
+              continue;
+            }
+          if((errno == EAGAIN) || (errno == EWOULDBLOCK))
+            {
+              struct pollfd pfd;
+              int rv;
+
+              pfd.fd = g_run.tty_fd;
+              pfd.events = POLLOUT;
+              pfd.revents = 0;
+
+              do
+                {
+                  rv = poll(&pfd, 1, g_signal_exit_requested ? 100 : -1);
+                }
+              while((g_terminal_force_output || !g_signal_exit_requested) &&
+                    (rv < 0) && (errno == EINTR));
+
+              if(rv > 0)
+                continue;
+            }
+          return;
+        }
+
+      if(n == 0)
+        {
+          struct pollfd pfd;
+          int rv;
+
+          pfd.fd = g_run.tty_fd;
+          pfd.events = POLLOUT;
+          pfd.revents = 0;
+
+          do
+            {
+              rv = poll(&pfd, 1, g_signal_exit_requested ? 100 : -1);
+            }
+          while((g_terminal_force_output || !g_signal_exit_requested) &&
+                (rv < 0) && (errno == EINTR));
+
+          if(rv > 0)
+            continue;
+          return;
+        }
+
+      data_  = (const char *)data_ + n;
+      size_ -= (size_t)n;
+    }
+}
+
+
+static
+bool
+_terminal_output_reserve(size_t add_)
+{
+  char *next;
+  size_t next_cap;
+
+  if(add_ == 0)
+    return true;
+
+  if(g_run.terminal_output_cap - g_run.terminal_output_len >= add_)
+    return true;
+
+  if(add_ > (SIZE_MAX - g_run.terminal_output_len))
+    return false;
+
+  next_cap = (g_run.terminal_output_cap > 0) ? g_run.terminal_output_cap : 65536U;
+  while(next_cap < (g_run.terminal_output_len + add_))
+    {
+      if(next_cap > (SIZE_MAX / 2U))
+        {
+          next_cap = g_run.terminal_output_len + add_;
+          break;
+        }
+      next_cap *= 2U;
+    }
+
+  next = realloc(g_run.terminal_output, next_cap);
+  if(next == NULL)
+    return false;
+
+  g_run.terminal_output = next;
+  g_run.terminal_output_cap = next_cap;
+  return true;
+}
+
+
+static
+void
+_terminal_output_append(const void *data_,
+                        size_t      size_)
+{
+  if((data_ == NULL) || (size_ == 0))
+    return;
+
+  if(!_terminal_output_reserve(size_))
+    {
+      g_run.terminal_output_batching = false;
+      if(g_run.terminal_output_len > 0)
+        {
+          _terminal_write_direct(g_run.terminal_output, g_run.terminal_output_len);
+          g_run.terminal_output_len = 0;
+        }
+      _terminal_write_direct(data_, size_);
+      return;
+    }
+
+  memcpy(g_run.terminal_output + g_run.terminal_output_len, data_, size_);
+  g_run.terminal_output_len += size_;
+}
+
+
+static
+void
+_terminal_output_begin(void)
+{
+  g_run.terminal_output_len = 0;
+  g_run.terminal_output_batching = true;
+}
+
+
+static
+void
+_terminal_output_flush(void)
+{
+  g_run.terminal_output_batching = false;
+  if(g_run.terminal_output_len > 0)
+    {
+      _terminal_write_direct(g_run.terminal_output, g_run.terminal_output_len);
+      g_run.terminal_output_len = 0;
+    }
+}
+
+
+static
+void
+_terminal_free_output_buffer(void)
+{
+  free(g_run.terminal_output);
+  g_run.terminal_output = NULL;
+  g_run.terminal_output_len = 0;
+  g_run.terminal_output_cap = 0;
+  g_run.terminal_output_batching = false;
+}
+
+
+static
+void
+_terminal_write_all(const void *data_,
+                    size_t      size_)
+{
+  if(g_run.terminal_output_batching)
+    _terminal_output_append(data_, size_);
+  else
+    _terminal_write_direct(data_, size_);
+}
+
+
+static
+void
+_terminal_update_size(void)
+{
+  struct winsize ws;
+
+  if(g_signal_resize_requested)
+    {
+      g_signal_resize_requested = 0;
+      g_run.terminal_resize_pending = true;
+    }
+
+  if(!g_run.terminal_resize_pending &&
+     (g_run.terminal_width > 0) && (g_run.terminal_height > 0))
+    return;
+
+  g_run.terminal_resize_pending = false;
+
+  if(ioctl(g_run.tty_fd, TIOCGWINSZ, &ws) != 0)
+    {
+      g_run.terminal_width = 80;
+      g_run.terminal_height = 24;
+      return;
+    }
+
+  if(ws.ws_col > 0)
+    g_run.terminal_width = ws.ws_col;
+  if(ws.ws_row > 0)
+    g_run.terminal_height = ws.ws_row;
+}
+
+
+static
+void
+_terminal_free_cell_cache(void)
+{
+  free(g_run.terminal_cells);
+  free(g_run.terminal_row_cells);
+  free(g_run.terminal_row_hashes);
+
+  g_run.terminal_cells = NULL;
+  g_run.terminal_row_cells = NULL;
+  g_run.terminal_row_hashes = NULL;
+  g_run.terminal_cache_cols = 0;
+  g_run.terminal_cache_rows = 0;
+}
+
+
+static
+void
+_terminal_free_coord_cache(void)
+{
+  free(g_run.terminal_src_x);
+  free(g_run.terminal_src_y_top);
+  free(g_run.terminal_src_y_bottom);
+
+  g_run.terminal_src_x = NULL;
+  g_run.terminal_src_y_top = NULL;
+  g_run.terminal_src_y_bottom = NULL;
+  g_run.terminal_map_width = 0;
+  g_run.terminal_map_height = 0;
+  g_run.terminal_map_cols = 0;
+  g_run.terminal_map_rows = 0;
+  g_run.terminal_map_render_mode = 0;
+}
+
+
+static
+bool
+_terminal_ensure_coord_cache(unsigned width_,
+                             unsigned height_,
+                             unsigned target_cols_,
+                             unsigned target_rows_,
+                             unsigned render_mode_)
+{
+  unsigned *src_x;
+  unsigned *src_y_top;
+  unsigned *src_y_bottom;
+  unsigned x;
+  unsigned y;
+  unsigned sub_rows;
+
+  if((width_ == 0U) || (height_ == 0U) ||
+     (target_cols_ == 0U) || (target_rows_ == 0U))
+    return false;
+
+  if((g_run.terminal_src_x != NULL) &&
+     (g_run.terminal_src_y_top != NULL) &&
+     (g_run.terminal_src_y_bottom != NULL) &&
+     (g_run.terminal_map_width == width_) &&
+     (g_run.terminal_map_height == height_) &&
+     (g_run.terminal_map_cols == target_cols_) &&
+     (g_run.terminal_map_rows == target_rows_) &&
+     (g_run.terminal_map_render_mode == render_mode_))
+    return true;
+
+  if(target_rows_ > (UINT_MAX / 2U))
+    return false;
+
+  src_x = malloc((size_t)target_cols_ * sizeof(*src_x));
+  src_y_top = malloc((size_t)target_rows_ * sizeof(*src_y_top));
+  src_y_bottom = malloc((size_t)target_rows_ * sizeof(*src_y_bottom));
+  if((src_x == NULL) || (src_y_top == NULL) || (src_y_bottom == NULL))
+    {
+      free(src_x);
+      free(src_y_top);
+      free(src_y_bottom);
+      return false;
+    }
+
+  for(x = 0; x < target_cols_; x++)
+    {
+      uint64_t sample = (((uint64_t)x * (uint64_t)width_) +
+                         ((uint64_t)width_ / 2ULL)) /
+        (uint64_t)target_cols_;
+      src_x[x] = (sample >= (uint64_t)width_) ? (width_ - 1U) : (unsigned)sample;
+    }
+
+  sub_rows = (render_mode_ == HARNESS_TERMINAL_RENDER_HALF) ?
+    (target_rows_ * 2U) : target_rows_;
+  for(y = 0; y < target_rows_; y++)
+    {
+      unsigned sub_y = (render_mode_ == HARNESS_TERMINAL_RENDER_HALF) ?
+        (y * 2U) : y;
+      uint64_t top = (((uint64_t)sub_y * (uint64_t)height_) +
+                      ((uint64_t)height_ / 2ULL)) / (uint64_t)sub_rows;
+      uint64_t bottom = (render_mode_ == HARNESS_TERMINAL_RENDER_HALF) ?
+        ((((uint64_t)(sub_y + 1U) * (uint64_t)height_) +
+          ((uint64_t)height_ / 2ULL)) / (uint64_t)sub_rows) : top;
+
+      src_y_top[y] = (top >= (uint64_t)height_) ? (height_ - 1U) : (unsigned)top;
+      src_y_bottom[y] = (bottom >= (uint64_t)height_) ? (height_ - 1U) : (unsigned)bottom;
+    }
+
+  _terminal_free_coord_cache();
+  g_run.terminal_src_x = src_x;
+  g_run.terminal_src_y_top = src_y_top;
+  g_run.terminal_src_y_bottom = src_y_bottom;
+  g_run.terminal_map_width = width_;
+  g_run.terminal_map_height = height_;
+  g_run.terminal_map_cols = target_cols_;
+  g_run.terminal_map_rows = target_rows_;
+  g_run.terminal_map_render_mode = render_mode_;
+
+  return true;
+}
+
+
+static
+bool
+_terminal_ensure_cell_cache(unsigned rows_,
+                            unsigned cols_)
+{
+  terminal_cell_t *cells;
+  terminal_cell_t *row_cells;
+  uint64_t *row_hashes;
+  size_t count;
+  unsigned y;
+
+  if((rows_ == 0U) || (cols_ == 0U))
+    return false;
+
+  if((g_run.terminal_cells != NULL) &&
+     (g_run.terminal_row_cells != NULL) &&
+     (g_run.terminal_cache_rows == rows_) &&
+     (g_run.terminal_cache_cols == cols_))
+    return true;
+
+  if((size_t)rows_ > (SIZE_MAX / (size_t)cols_))
+    return false;
+
+  count = (size_t)rows_ * (size_t)cols_;
+  if(count > (SIZE_MAX / sizeof(*cells)))
+    return false;
+
+  cells = malloc(count * sizeof(*cells));
+  row_cells = malloc((size_t)cols_ * sizeof(*row_cells));
+  row_hashes = malloc((size_t)rows_ * sizeof(*row_hashes));
+  if((cells == NULL) || (row_cells == NULL) || (row_hashes == NULL))
+    {
+      free(cells);
+      free(row_cells);
+      free(row_hashes);
+      return false;
+    }
+
+  memset(cells, 0, count * sizeof(*cells));
+  for(y = 0; y < rows_; y++)
+    row_hashes[y] = UINT64_MAX;
+  _terminal_free_cell_cache();
+
+  g_run.terminal_cells = cells;
+  g_run.terminal_row_cells = row_cells;
+  g_run.terminal_row_hashes = row_hashes;
+  g_run.terminal_cache_rows = rows_;
+  g_run.terminal_cache_cols = cols_;
+
+  return true;
+}
+
+
+static
+void
+_terminal_fill_blank_cells(terminal_cell_t *cells_,
+                           unsigned         count_)
+{
+  memset(cells_, 0, (size_t)count_ * sizeof(cells_[0]));
+}
+
+
+static
+uint64_t
+_terminal_hash_cells(const terminal_cell_t *cells_,
+                     unsigned               count_)
+{
+  const uint8_t *p = (const uint8_t *)cells_;
+  size_t len = (size_t)count_ * sizeof(*cells_);
+  uint64_t hash = 1469598103934665603ULL;
+  size_t i;
+
+  for(i = 0; i < len; i++)
+    {
+      hash ^= p[i];
+      hash *= 1099511628211ULL;
+    }
+
+  return hash;
+}
+
+
+static
+void
+_terminal_emit_cells(unsigned               row_,
+                     unsigned               col_,
+                     const terminal_cell_t *cells_,
+                     unsigned               cols_)
+{
+  static const char half_upper[] = "\xe2\x96\x80";
+  unsigned x = 0;
+  bool have_fg = false;
+  bool have_bg = false;
+  uint8_t prev_fg_r = 0;
+  uint8_t prev_fg_g = 0;
+  uint8_t prev_fg_b = 0;
+  uint8_t prev_bg_r = 0;
+  uint8_t prev_bg_g = 0;
+  uint8_t prev_bg_b = 0;
+
+  _terminal_move_cursor(row_, col_);
+  _terminal_write_all("\x1b[0m", sizeof("\x1b[0m") - 1);
+
+  while(x < cols_)
+    {
+      const terminal_cell_t *cell = &cells_[x];
+
+      if(cell->glyph == HARNESS_TERMINAL_CELL_BLANK)
+        {
+          unsigned start = x;
+
+          do
+            x++;
+          while((x < cols_) &&
+                (cells_[x].glyph == HARNESS_TERMINAL_CELL_BLANK));
+
+          if(have_fg || have_bg)
+            {
+              _terminal_write_all("\x1b[0m", sizeof("\x1b[0m") - 1);
+              have_fg = false;
+              have_bg = false;
+            }
+          _terminal_write_spaces((size_t)(x - start));
+          continue;
+        }
+
+      bool need_bg = !have_bg || (cell->bg_r != prev_bg_r) ||
+        (cell->bg_g != prev_bg_g) || (cell->bg_b != prev_bg_b);
+
+      if(cell->glyph == HARNESS_TERMINAL_CELL_BG_SPACE)
+        {
+          unsigned start = x;
+
+          if(need_bg)
+            {
+              _terminal_write_sgr_rgb(false, 0, 0, 0,
+                                      true, cell->bg_r, cell->bg_g, cell->bg_b);
+              prev_bg_r = cell->bg_r;
+              prev_bg_g = cell->bg_g;
+              prev_bg_b = cell->bg_b;
+              have_bg = true;
+            }
+
+          do
+            x++;
+          while((x < cols_) &&
+                (cells_[x].glyph == HARNESS_TERMINAL_CELL_BG_SPACE) &&
+                (cells_[x].bg_r == prev_bg_r) &&
+                (cells_[x].bg_g == prev_bg_g) &&
+                (cells_[x].bg_b == prev_bg_b));
+
+          _terminal_write_spaces((size_t)(x - start));
+          continue;
+        }
+
+      if(cell->glyph == HARNESS_TERMINAL_CELL_ASCII)
+        {
+          unsigned start = x;
+          char ch = (char)((cell->ch == 0U) ? ' ' : cell->ch);
+          bool need_fg = !have_fg || (cell->fg_r != prev_fg_r) ||
+            (cell->fg_g != prev_fg_g) || (cell->fg_b != prev_fg_b);
+
+          if(need_fg)
+            {
+              _terminal_write_sgr_rgb(true, cell->fg_r, cell->fg_g, cell->fg_b,
+                                      false, 0, 0, 0);
+              prev_fg_r = cell->fg_r;
+              prev_fg_g = cell->fg_g;
+              prev_fg_b = cell->fg_b;
+              have_fg = true;
+            }
+
+          do
+            x++;
+          while((x < cols_) &&
+                (cells_[x].glyph == HARNESS_TERMINAL_CELL_ASCII) &&
+                (cells_[x].ch == (uint8_t)ch) &&
+                (cells_[x].fg_r == prev_fg_r) &&
+                (cells_[x].fg_g == prev_fg_g) &&
+                (cells_[x].fg_b == prev_fg_b));
+
+          _terminal_write_repeat_char(ch, x - start);
+          continue;
+        }
+
+      bool need_fg = !have_fg || (cell->fg_r != prev_fg_r) ||
+        (cell->fg_g != prev_fg_g) || (cell->fg_b != prev_fg_b);
+
+      if(need_fg || need_bg)
+        {
+          _terminal_write_sgr_rgb(need_fg, cell->fg_r, cell->fg_g, cell->fg_b,
+                                  need_bg, cell->bg_r, cell->bg_g, cell->bg_b);
+          if(need_fg)
+            {
+              prev_fg_r = cell->fg_r;
+              prev_fg_g = cell->fg_g;
+              prev_fg_b = cell->fg_b;
+              have_fg = true;
+            }
+          if(need_bg)
+            {
+              prev_bg_r = cell->bg_r;
+              prev_bg_g = cell->bg_g;
+              prev_bg_b = cell->bg_b;
+              have_bg = true;
+            }
+        }
+
+      {
+        unsigned start = x;
+
+        do
+          x++;
+        while((x < cols_) &&
+              (cells_[x].glyph == HARNESS_TERMINAL_CELL_HALF_UPPER) &&
+              (cells_[x].fg_r == prev_fg_r) &&
+              (cells_[x].fg_g == prev_fg_g) &&
+              (cells_[x].fg_b == prev_fg_b) &&
+              (cells_[x].bg_r == prev_bg_r) &&
+              (cells_[x].bg_g == prev_bg_g) &&
+              (cells_[x].bg_b == prev_bg_b));
+
+        _terminal_write_repeat_utf8(half_upper, sizeof(half_upper) - 1,
+                                    x - start);
+      }
+    }
+
+  _terminal_write_all("\x1b[0m", sizeof("\x1b[0m") - 1);
+}
+
+
+static
+bool
+_terminal_button_from_key(int      key_,
+                          unsigned *id_)
+{
+  switch(key_)
+    {
+    case 'w':
+    case 'W':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_UP;
+      return true;
+    case 'a':
+    case 'A':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_LEFT;
+      return true;
+    case 's':
+    case 'S':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_DOWN;
+      return true;
+    case 'd':
+    case 'D':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+      return true;
+    case 'j':
+    case 'J':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_Y;
+      return true;
+    case 'k':
+    case 'K':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_B;
+      return true;
+    case 'l':
+    case 'L':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_A;
+      return true;
+    case 'u':
+    case 'U':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_L;
+      return true;
+    case 'i':
+    case 'I':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_R;
+      return true;
+    case '\'':
+      *id_ = RETRO_DEVICE_ID_JOYPAD_SELECT;
+      return true;
+    default:
+      return false;
+    }
+}
+
+
+static
+void
+_terminal_press_button(unsigned button_)
+{
+  if(button_ >= HARNESS_TERMINAL_BUTTONS)
+    return;
+
+  g_run.terminal_button_mask_next |= (uint16_t)(1U << button_);
+}
+
+
+static
+void
+_terminal_update_button_mask(uint64_t frame_)
+{
+  unsigned i;
+
+  for(i = 0; i < HARNESS_TERMINAL_BUTTONS; i++)
+    {
+      if((g_run.terminal_button_mask_next & (1U << i)) != 0)
+        {
+          g_run.terminal_button_expire[i] =
+            (UINT64_MAX - frame_ <= (uint64_t)g_cfg.terminal_button_hold_frames) ?
+            UINT64_MAX :
+            (frame_ + (uint64_t)(g_cfg.terminal_button_hold_frames == 0 ? 1 :
+                                 g_cfg.terminal_button_hold_frames));
+        }
+    }
+
+  g_run.terminal_button_mask_next = 0;
+
+  g_run.terminal_button_mask = 0;
+  for(i = 0; i < HARNESS_TERMINAL_BUTTONS; i++)
+    {
+      uint64_t expire = g_run.terminal_button_expire[i];
+
+      if((expire != 0) && (frame_ < expire))
+        g_run.terminal_button_mask |= (uint16_t)(1U << i);
+      else
+        g_run.terminal_button_expire[i] = 0;
+    }
+}
+
+
+static
+void
+_terminal_parse_input_byte(uint8_t byte_)
+{
+  int key = (int)byte_;
+  bool button_ok;
+  unsigned button;
+
+  if(g_run.terminal_escape == 1)
+    {
+      if(key == '[')
+        {
+          g_run.terminal_escape = 2;
+          return;
+        }
+      else if(key == 'O')
+        {
+          g_run.terminal_escape = 3;
+          return;
+        }
+      else if(key == 27)
+        {
+          g_run.terminal_quit_requested = true;
+          g_run.terminal_escape = 0;
+          return;
+        }
+
+      g_run.terminal_escape = 0;
+    }
+
+  if(g_run.terminal_escape == 2)
+    {
+      if(((key >= '0') && (key <= '9')) || (key == ';') || (key == '?'))
+        return;
+
+      if(key == 'A')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_UP);
+      else if(key == 'B')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_DOWN);
+      else if(key == 'D')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_LEFT);
+      else if(key == 'C')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_RIGHT);
+
+      g_run.terminal_escape = 0;
+      return;
+    }
+
+  if(g_run.terminal_escape == 3)
+    {
+      if(key == 'A')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_UP);
+      else if(key == 'B')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_DOWN);
+      else if(key == 'D')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_LEFT);
+      else if(key == 'C')
+        _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_RIGHT);
+
+      g_run.terminal_escape = 0;
+      return;
+    }
+
+  if(key == 27)
+    {
+      g_run.terminal_escape = 1;
+      return;
+    }
+
+  if((key == 10) || (key == 13))
+    {
+      _terminal_press_button(RETRO_DEVICE_ID_JOYPAD_START);
+      return;
+    }
+
+  if(key == 3)
+    {
+      g_run.terminal_quit_requested = true;
+      return;
+    }
+
+  button_ok = _terminal_button_from_key(key, &button);
+  if(button_ok)
+    _terminal_press_button(button);
+}
+
+
+static
+void
+_terminal_poll_input(void)
+{
+  uint8_t buffer[128];
+  ssize_t n;
+
+  if(!g_run.terminal_active || (g_run.tty_fd < 0))
+    return;
+
+  while((n = read(g_run.tty_fd, buffer, sizeof(buffer))) > 0)
+    {
+      size_t i;
+
+      for(i = 0; i < (size_t)n; i++)
+        _terminal_parse_input_byte(buffer[i]);
+    }
+
+  if((n < 0) && (errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINTR))
+    _harness_log(RETRO_LOG_WARN,
+                 "[Harness]: terminal input read failed: %s\n", strerror(errno));
+
+  _terminal_update_button_mask(g_run.current_frame);
+}
+
+
+static
+int
+_terminal_open(void)
+{
+  struct termios raw;
+
+  g_run.tty_fd = open("/dev/tty", O_RDWR | O_NOCTTY);
+  if(g_run.tty_fd < 0)
+    {
+      _harness_log(RETRO_LOG_ERROR,
+                   "[Harness]: unable to open terminal: %s\n",
+                   strerror(errno));
+      g_run.tty_fd = -1;
+      return -1;
+    }
+
+  memset(g_run.terminal_button_expire, 0, sizeof(g_run.terminal_button_expire));
+  g_run.terminal_button_mask = 0;
+  g_run.terminal_button_mask_next = 0;
+  g_run.terminal_resize_pending = true;
+  g_run.terminal_escape = 0;
+  g_run.terminal_quit_requested = false;
+  g_run.terminal_last_render_frame = 0;
+  g_run.terminal_adaptive_fps = g_cfg.terminal_fps;
+  g_run.terminal_render_seconds_ema = 0.0;
+  _terminal_detect_capabilities();
+
+  g_run.tty_flags = fcntl(g_run.tty_fd, F_GETFL, 0);
+  if(g_run.tty_flags < 0)
+    {
+      g_run.tty_flags = -1;
+    }
+
+  if(tcgetattr(g_run.tty_fd, &g_run.tty_orig_termios) != 0)
+    {
+      close(g_run.tty_fd);
+      g_run.tty_fd = -1;
+      return -1;
+    }
+
+  raw = g_run.tty_orig_termios;
+  raw.c_iflag &= ~(IXON | ICRNL | INLCR | IGNCR | BRKINT | INPCK | ISTRIP);
+  raw.c_oflag &= ~OPOST;
+  raw.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+  raw.c_cc[VMIN] = 0;
+  raw.c_cc[VTIME] = 0;
+
+  if(tcsetattr(g_run.tty_fd, TCSAFLUSH, &raw) != 0)
+    {
+      close(g_run.tty_fd);
+      g_run.tty_fd = -1;
+      return -1;
+    }
+
+  if(g_run.tty_flags >= 0)
+    (void)fcntl(g_run.tty_fd, F_SETFL, g_run.tty_flags | O_NONBLOCK);
+
+  _terminal_update_size();
+  g_run.terminal_active = true;
+
+  _terminal_write_all("\x1b[?1049h\x1b[?25l\x1b[2J",
+                      sizeof("\x1b[?1049h\x1b[?25l\x1b[2J") - 1);
+
+  return 0;
+}
+
+
+static
+void
+_terminal_close(void)
+{
+  if(g_run.tty_fd < 0)
+    return;
+
+  g_terminal_force_output = true;
+  _terminal_output_flush();
+  _terminal_write_all("\x1b[0m\x1b[?25h\x1b[?1049l",
+                      sizeof("\x1b[0m\x1b[?25h\x1b[?1049l") - 1);
+  g_terminal_force_output = false;
+
+  if((g_run.tty_flags >= 0))
+    (void)fcntl(g_run.tty_fd, F_SETFL, g_run.tty_flags);
+
+  (void)tcsetattr(g_run.tty_fd, TCSAFLUSH, &g_run.tty_orig_termios);
+
+  close(g_run.tty_fd);
+  g_run.tty_fd = -1;
+  g_run.terminal_active = false;
+  _terminal_free_cell_cache();
+  _terminal_free_coord_cache();
+  _terminal_free_output_buffer();
+}
+
+
+static
+void
+_terminal_render_frame(const void             *data_,
+                       unsigned                width_,
+                       unsigned                height_,
+                       size_t                  pitch_,
+                       enum retro_pixel_format  fmt_)
+{
+  unsigned y;
+  static int last_display_cols;
+  static int last_display_rows;
+  unsigned display_cols;
+  unsigned image_rows_max;
+  unsigned display_rows;
+  unsigned target_cols;
+  unsigned target_rows;
+  unsigned full_rows_for_full_width;
+  unsigned full_cols_for_full_rows;
+  unsigned pad_left;
+  unsigned pad_top;
+  uint64_t src_aspect_ratio_n;
+  uint64_t src_aspect_ratio_d;
+  terminal_cell_t *row_cells;
+  size_t cell_size;
+  terminal_read_pixel_fn read_pixel;
+
+  if(!g_run.terminal_active || (data_ == NULL) ||
+     (width_ == 0) || (height_ == 0))
+    return;
+
+  _terminal_update_size();
+  if((g_run.terminal_width < 1) || (g_run.terminal_height < 1))
+    return;
+
+  display_cols = (unsigned)g_run.terminal_width;
+  display_rows = (unsigned)g_run.terminal_height;
+
+  if((display_cols == 0) || (display_rows == 0))
+    return;
+
+  image_rows_max = (display_rows > 1U) ? (display_rows - 1U) : 1U;
+
+  src_aspect_ratio_n = (uint64_t)width_ * 2ULL;
+  src_aspect_ratio_d = (uint64_t)height_;
+
+  full_rows_for_full_width = _terminal_u64_ceil_div((uint64_t)height_ *
+                                                    (uint64_t)display_cols,
+                                                    src_aspect_ratio_n);
+  full_cols_for_full_rows = _terminal_u64_ceil_div(src_aspect_ratio_n *
+                                                   (uint64_t)image_rows_max,
+                                                   src_aspect_ratio_d);
+
+  if((full_rows_for_full_width == 0U) || (full_cols_for_full_rows == 0U))
+    return;
+
+  if(full_rows_for_full_width > image_rows_max)
+    {
+      target_cols = full_cols_for_full_rows;
+      target_rows = image_rows_max;
+    }
+  else
+    {
+      target_cols = display_cols;
+      target_rows = full_rows_for_full_width;
+    }
+
+  if(target_cols > display_cols)
+    target_cols = display_cols;
+  if(target_rows > image_rows_max)
+    target_rows = image_rows_max;
+
+  if((target_cols == 0U) || (target_rows == 0U))
+    return;
+
+  if(!_terminal_ensure_coord_cache(width_, height_, target_cols, target_rows,
+                                   (unsigned)g_run.terminal_render_mode))
+    return;
+
+  if(!_terminal_ensure_cell_cache(image_rows_max, display_cols))
+    return;
+
+  if(g_run.terminal_read_pixel == NULL)
+    _terminal_set_pixel_reader(fmt_);
+  read_pixel = g_run.terminal_read_pixel;
+
+  row_cells = g_run.terminal_row_cells;
+  cell_size = sizeof(*row_cells);
+
+  _terminal_output_begin();
+
+  if((display_cols != (unsigned)last_display_cols) ||
+     (display_rows != (unsigned)last_display_rows))
+    {
+      size_t cache_count = (size_t)image_rows_max * (size_t)display_cols;
+
+      _terminal_write_all("\x1b[2J\x1b[H", 7);
+      memset(g_run.terminal_cells, 0xff, cache_count * sizeof(*g_run.terminal_cells));
+      for(y = 0; y < image_rows_max; y++)
+        g_run.terminal_row_hashes[y] = UINT64_MAX;
+      last_display_cols = (int)display_cols;
+      last_display_rows = (int)display_rows;
+    }
+
+  pad_left = (display_cols > target_cols)
+    ? ((display_cols - target_cols) / 2U)
+    : 0U;
+  pad_top = (image_rows_max > target_rows)
+    ? ((image_rows_max - target_rows) / 2U)
+    : 0U;
+
+  for(y = 0; y < image_rows_max; y++)
+    {
+      bool draw_row = (y >= pad_top) && (y < (pad_top + target_rows));
+      terminal_cell_t *cached_row =
+        &g_run.terminal_cells[(size_t)y * (size_t)display_cols];
+      uint64_t row_hash;
+      unsigned x2;
+
+      _terminal_fill_blank_cells(row_cells, display_cols);
+
+      if(draw_row)
+        {
+          unsigned map_y = y - pad_top;
+          unsigned src_y_top = g_run.terminal_src_y_top[map_y];
+          unsigned src_y_bottom = g_run.terminal_src_y_bottom[map_y];
+
+          for(x2 = 0; x2 < target_cols; x2++)
+            {
+              unsigned src_x = g_run.terminal_src_x[x2];
+              terminal_cell_t *cell = &row_cells[pad_left + x2];
+              uint32_t top = read_pixel(data_, pitch_, src_x, src_y_top);
+
+              if(g_run.terminal_render_mode == HARNESS_TERMINAL_RENDER_HALF)
+                {
+                  uint32_t bottom = read_pixel(data_, pitch_, src_x, src_y_bottom);
+
+                  _terminal_store_color(bottom, &cell->bg_r, &cell->bg_g,
+                                        &cell->bg_b);
+                  _terminal_store_color(top, &cell->fg_r, &cell->fg_g,
+                                        &cell->fg_b);
+                  cell->glyph = HARNESS_TERMINAL_CELL_HALF_UPPER;
+                }
+              else
+                {
+                  static const char ramp[] = " .:-=+*#%@";
+                  unsigned r = (top >> 16U) & 0xffU;
+                  unsigned g = (top >> 8U) & 0xffU;
+                  unsigned b = top & 0xffU;
+                  unsigned bright = (299U * r + 587U * g + 114U * b) / 1000U;
+                  size_t idx = ((size_t)bright * (sizeof(ramp) - 2U)) / 255U;
+
+                  _terminal_store_color(top, &cell->fg_r, &cell->fg_g,
+                                        &cell->fg_b);
+                  cell->glyph = HARNESS_TERMINAL_CELL_ASCII;
+                  cell->ch = (uint8_t)ramp[idx];
+                }
+            }
+        }
+
+      row_hash = _terminal_hash_cells(row_cells, display_cols);
+      if(row_hash != g_run.terminal_row_hashes[y])
+        {
+          unsigned first = 0;
+          unsigned last = display_cols;
+
+          while((first < display_cols) &&
+                (memcmp(&row_cells[first], &cached_row[first], cell_size) == 0))
+            first++;
+
+          while((last > first) &&
+                (memcmp(&row_cells[last - 1U], &cached_row[last - 1U], cell_size) == 0))
+            last--;
+
+          if(first < last)
+            {
+              _terminal_emit_cells(y + 1U, first + 1U, &row_cells[first], last - first);
+              memcpy(&cached_row[first], &row_cells[first], (size_t)(last - first) * cell_size);
+            }
+          g_run.terminal_row_hashes[y] = row_hash;
+        }
+    }
+
+  if(display_rows > 1U)
+    {
+      char status[256];
+      size_t status_len;
+      int n = snprintf(status,
+                       sizeof(status),
+                       "frame=%" PRIu64 " input_mask=0x%04x %s",
+                       g_run.current_frame,
+                       g_run.terminal_button_mask,
+                       g_run.terminal_quit_requested ? "(quit requested)" :
+                       "(WASD/Arrows=UDLR, J=A, K=B, L=C, '=X, "
+                       "U=LT, I=RT, Enter=Play, Esc Esc=Quit)");
+      if(n > 0)
+        {
+          status_len = (size_t)n;
+          if(status_len > display_cols)
+            status_len = display_cols;
+
+          _terminal_move_cursor(image_rows_max + 1U, 1U);
+          _terminal_write_all("\x1b[0m", sizeof("\x1b[0m") - 1);
+          _terminal_write_all(status, status_len);
+          if(status_len < display_cols)
+            _terminal_write_spaces(display_cols - status_len);
+        }
+    }
+
+  _terminal_output_flush();
+}
+
+
 RETRO_CALLCONV
 static
 void
 _harness_input_poll(void)
 {
+  if(!g_cfg.terminal_mode)
+    return;
+
+  _terminal_poll_input();
 }
+
 
 RETRO_CALLCONV
 static
@@ -2531,8 +4862,18 @@ _harness_input_state(unsigned port_,
         return 1;
     }
 
+  if(g_cfg.terminal_mode)
+    {
+      _terminal_update_button_mask(g_run.current_frame);
+      mask |= g_run.terminal_button_mask;
+    }
+
   if(id_ == RETRO_DEVICE_ID_JOYPAD_MASK)
     return (int16_t)mask;
+
+  if((id_ < HARNESS_TERMINAL_BUTTONS) &&
+     ((mask & (uint16_t)(1U << id_)) != 0))
+    return 1;
 
   return 0;
 }
@@ -2648,6 +4989,8 @@ _compute_target_frames(void)
 
   if(g_cfg.have_frames)
     g_run.target_frames = g_cfg.frames;
+  else if(g_cfg.terminal_mode)
+    g_run.target_frames = UINT64_MAX;
   else
     g_run.target_frames = 300;
 
@@ -2963,6 +5306,27 @@ _write_metrics(const char *status_,
     _json_string(f, g_cfg.screenshot_path);
   else
     fputs("null", f);
+  fprintf(f, ",\n  \"screenshot_every_dir\": ");
+  if(g_cfg.screenshot_every_dir)
+    _json_string(f, g_cfg.screenshot_every_dir);
+  else
+    fputs("null", f);
+  fprintf(f, ",\n  \"screenshot_every_step\": ");
+  if(g_cfg.screenshot_every_step > 0)
+    fprintf(f, "%" PRIu64, g_cfg.screenshot_every_step);
+  else
+    fputs("null", f);
+  fprintf(f, ",\n  \"screenshot_every_written\": %" PRIu64,
+          g_cfg.screenshot_every_written);
+  fprintf(f, ",\n  \"screenshot_when_mode\": ");
+  switch(g_cfg.screenshot_when_mode)
+    {
+    case SCREENSHOT_WHEN_NONBLANK: fprintf(f, "\"nonblank\""); break;
+    case SCREENSHOT_WHEN_CHANGED:  fprintf(f, "\"changed\"");  break;
+    default:                       fputs("null", f);          break;
+    }
+  fprintf(f, ",\n  \"screenshot_when_skipped\": %" PRIu64,
+          g_cfg.screenshot_when_skipped);
   fprintf(f, ",\n  \"requested_frames\": ");
   if(g_cfg.have_frames)
     fprintf(f, "%" PRIu64, g_cfg.frames);
@@ -3041,7 +5405,7 @@ _write_final_screenshot(void)
       return -1;
     }
 
-  return _write_ppm(g_cfg.screenshot_path,
+  return _write_png(g_cfg.screenshot_path,
                     g_run.last_frame,
                     g_run.last_width,
                     g_run.last_height,
@@ -3069,7 +5433,7 @@ _write_requested_screenshots(void)
           continue;
         }
 
-      if(_write_ppm(shot->path,
+      if(_write_png(shot->path,
                     shot->data,
                     shot->width,
                     shot->height,
@@ -3125,8 +5489,16 @@ main(int    argc_,
   g_run.pixel_format = RETRO_PIXEL_FORMAT_0RGB1555;
   g_run.last_pixel_format = RETRO_PIXEL_FORMAT_0RGB1555;
 
+  _install_signal_handlers();
   _validate_arg_followers(argc_, argv_);
   _parse_args(argc_, argv_);
+
+  if(g_cfg.list_bios)
+    {
+      _print_bios_list(stdout);
+      return 0;
+    }
+
   _prepare_paths();
 
   if(_setup_logging() != 0)
@@ -3175,6 +5547,15 @@ main(int    argc_,
   api.set_audio_sample_batch(_harness_audio_sample_batch);
   api.set_input_poll(_harness_input_poll);
   api.set_input_state(_harness_input_state);
+
+  if(g_cfg.terminal_mode && (_terminal_open() != 0))
+    {
+      _harness_log(RETRO_LOG_WARN,
+                   "[Harness]: terminal mode unavailable; continuing without live terminal\n"
+                   "          details: %s\n", strerror(errno));
+      g_cfg.terminal_mode = false;
+    }
+
   api.init();
   g_run.core_initialized = true;
 
@@ -3207,6 +5588,9 @@ main(int    argc_,
   start = _monotonic_seconds();
   while(g_run.frames_run < g_run.target_frames)
     {
+      if(g_signal_exit_requested)
+        break;
+
       frame = g_run.frames_run + 1;
       if(frame == g_run.benchmark_start_frame)
         {
@@ -3215,6 +5599,7 @@ main(int    argc_,
         }
 
       g_run.current_frame = frame;
+      double frame_start = _monotonic_seconds();
       api.run();
       g_run.frames_run++;
 
@@ -3228,12 +5613,26 @@ main(int    argc_,
           g_run.benchmark_finished = true;
         }
 
+      if(g_signal_exit_requested)
+        break;
+
+      if(g_run.terminal_quit_requested)
+        break;
+
+      if(g_cfg.terminal_mode)
+        {
+          double frame_elapsed = _monotonic_seconds() - frame_start;
+          if(g_run.core_fps > 0.0)
+            _sleep_for_seconds((1.0 / g_run.core_fps) - frame_elapsed);
+        }
+
       if((g_cfg.wall_timeout > 0.0) &&
          ((_monotonic_seconds() - start) >= g_cfg.wall_timeout))
         {
           g_run.timed_out = true;
           break;
         }
+
     }
   end = _monotonic_seconds();
   g_run.wall_seconds = end - start;
@@ -3250,6 +5649,18 @@ main(int    argc_,
       status = "timeout";
       exit_code = 124;
     }
+  else if(g_signal_exit_requested)
+    {
+      int signo = (int)g_signal_exit_number;
+
+      status = "signal";
+      exit_code = 128 + ((signo > 0) ? signo : SIGTERM);
+    }
+  else if(g_run.terminal_quit_requested)
+    {
+      status = "quit";
+      exit_code = 0;
+    }
   else if(g_run.artifact_error)
     {
       status = "artifact_error";
@@ -3262,6 +5673,7 @@ main(int    argc_,
     }
 
  cleanup:
+  _terminal_close();
   _close_audio();
 
   if(g_run.loaded_game && api.unload_game != NULL)
@@ -3311,6 +5723,7 @@ main(int    argc_,
     }
 
   free(g_run.last_frame);
+  free(g_run.screenshot_when_prev);
   _free_screenshot_captures();
   return exit_code;
 }


### PR DESCRIPTION
- Add live terminal framebuffer mode with keyboard input, rendering/color controls, adaptive redraw, and graceful quit/signal handling.
- Switch screenshot artifacts to PNG via stb_image_write, including periodic and filtered screenshot capture metrics.
- Add WAV audio capture controls, input-file support, BIOS listing, Makefile linkage, and opera-test-harness skill documentation.